### PR TITLE
Makefiles for examples

### DIFF
--- a/PenguinV/Library/blob_detection.cpp
+++ b/PenguinV/Library/blob_detection.cpp
@@ -1,3 +1,4 @@
+#include <cmath>
 #include <numeric>
 #include <queue>
 #include "blob_detection.h"

--- a/PenguinV/examples/bitmap_operation/README.md
+++ b/PenguinV/examples/bitmap_operation/README.md
@@ -7,3 +7,9 @@ In this folder you need to type/paste this text in terminal:
 	```cpp
 	g++ -std=c++11 -Wall example_bitmap_operation.cpp ../../Library/image_function.cpp ../../Library/FileOperation/bitmap.cpp -o application
 	```
+- make
+In this folder type:
+        ```bash
+        make
+        ./example_bitmap_operation
+        ```

--- a/PenguinV/examples/bitmap_operation/makefile
+++ b/PenguinV/examples/bitmap_operation/makefile
@@ -1,0 +1,10 @@
+##
+# Flags for C++ compiler
+##
+CXXFLAGS += -std=c++11 -Wall
+
+example_bitmap_operation : ../../Library/image_function.cpp ../../Library/FileOperation/bitmap.cpp
+
+.PHONY: clean
+clean:
+	$(RM) example_bitmap_operation

--- a/PenguinV/examples/blob_detection/README.md
+++ b/PenguinV/examples/blob_detection/README.md
@@ -7,3 +7,10 @@ In this folder you need to type/paste this text in terminal:
 	```cpp
 	g++ -std=c++11 -Wall example_blob_detection.cpp ../../Library/image_function.cpp ../../Library/blob_detection.cpp ../../Library/FileOperation/bitmap.cpp -o application
 	```
+
+- make
+In this folder type:
+        ```bash
+        make
+        ./example_blob_detection
+        ```

--- a/PenguinV/examples/blob_detection/makefile
+++ b/PenguinV/examples/blob_detection/makefile
@@ -1,0 +1,10 @@
+##
+# Flags for C++ compiler
+##
+CXXFLAGS += -std=c++11 -Wall
+
+example_blob_detection : ../../Library/image_function.cpp ../../Library/blob_detection.cpp ../../Library/FileOperation/bitmap.cpp
+
+.PHONY: clean
+clean:
+	$(RM) example_blob_detection

--- a/PenguinV/examples/function_pool/README.md
+++ b/PenguinV/examples/function_pool/README.md
@@ -7,3 +7,9 @@ In this folder you need to type/paste this text in terminal:
 	```cpp
 	g++ -std=c++11 -pthread -Wall example_function_pool.cpp ../../Library/image_function.cpp ../../Library/thread_pool.cpp ../../Library/function_pool.cpp -o application
 	```
+- make
+In this folder type:
+        ```bash
+        make
+        ./example_function_pool
+        ```

--- a/PenguinV/examples/function_pool/makefile
+++ b/PenguinV/examples/function_pool/makefile
@@ -1,0 +1,11 @@
+##
+# Flags for C++ compiler
+##
+CXXFLAGS += -std=c++11 -Wall
+LDFLAGS += -pthread
+
+example_function_pool : ../../Library/image_function.cpp ../../Library/thread_pool.cpp ../../Library/function_pool.cpp
+
+.PHONY: clean
+clean:
+	$(RM) example_function_pool

--- a/PenguinV/examples/image_function/README.md
+++ b/PenguinV/examples/image_function/README.md
@@ -7,3 +7,10 @@ In this folder you need to type/paste this text in terminal:
 	```cpp
 	g++ -std=c++11 -Wall example_image_function.cpp ../../Library/image_function.cpp -o application
 	```
+
+- make
+In this folder type:
+        ```bash
+        make
+        ./example_image_function
+        ```

--- a/PenguinV/examples/image_function/makefile
+++ b/PenguinV/examples/image_function/makefile
@@ -1,0 +1,10 @@
+##
+# Flags for C++ compiler
+##
+CXXFLAGS += -std=c++11 -Wall
+
+example_image_function : ../../Library/image_function.cpp
+
+.PHONY: clean
+clean:
+	$(RM) example_image_function

--- a/PenguinV/examples/thread_pool/README.md
+++ b/PenguinV/examples/thread_pool/README.md
@@ -7,3 +7,10 @@ In this folder you need to type/paste this text in terminal:
 	```cpp
 	g++ -std=c++11 -pthread -Wall example_thread_pool.cpp ../../Library/image_function.cpp ../../Library/thread_pool.cpp -o application
 	```
+
+- make
+In this folder type:
+        ```bash
+        make
+        ./example_thread_pool
+        ```

--- a/PenguinV/examples/thread_pool/makefile
+++ b/PenguinV/examples/thread_pool/makefile
@@ -1,0 +1,11 @@
+##
+# Flags for C++ compiler
+##
+CXXFLAGS += -std=c++11 -Wall
+LDFLAGS += -pthread
+
+example_thread_pool : ../../Library/image_function.cpp ../../Library/thread_pool.cpp
+
+.PHONY: clean
+clean:
+	$(RM) example_thread_pool


### PR DESCRIPTION
@ihhub:

- I added makefiles for all the examples, except `qt_framework` (I couldn't get that to build)
- in order to get `blob_detection` to build, I had to include `cmath`. See 0ccc908 (it wouldn't build using the instructions in the readme)
- I've relied on `make` as much as possible. Everything is laid out the same and will be easy for you to maintain. It'll also be clear to someone that knows make. It's always `target : dependencies`.
- Each of the executables are named after the C++ file instead of `application`. That allows the makefile to be minimal since make understands that. If you want everything to be copied, it can be done.
- The way it's set up, it will respect the dependencies listed. It doesn't create a dependency tree by running the compiler on the files. This is easier to deal with especially on a smaller project, but you won't have automatic rebuilding when you change a file that's included by one of those files listed.
- This isn't cross platform, but you already have MSVC projects, so I don't think that's a big deal.
- I updated the doc to include `make`.
- There's also a `make clean` target that removes the executable.
- If you want to change the compiler, you can do so when calling make: `make CXX=clang++`

I think that's it for now.