### PR TITLE
Using vector::empty() instead of vector::clear()

### DIFF
--- a/PenguinV/Library/function_pool.cpp
+++ b/PenguinV/Library/function_pool.cpp
@@ -158,7 +158,7 @@ namespace Function_Pool
 			for( std::vector < uint32_t >::const_iterator value = sum.begin(); value != sum.end(); ++value )
 				total += *value;
 
-			sum.empty(); // to guarantee that no one can use it second time
+			sum.clear(); // to guarantee that no one can use it second time
 
 			return total;
 		}


### PR DESCRIPTION
I noticed that function_pool::getSum() is using sum.empty()  before returning.
The return type of which is ignored and the comment next to it seem to imply that clear() was the original intention...?