### PR TITLE
add sum to arm neon

### DIFF
--- a/test/performance_tests/performance_test_image_function.cpp
+++ b/test/performance_tests/performance_test_image_function.cpp
@@ -394,6 +394,7 @@ namespace image_function_neon
     SET_FUNCTION( Maximum            )
     SET_FUNCTION( Minimum            )
     SET_FUNCTION( Subtract           )
+    SET_FUNCTION( Sum                )
     SET_FUNCTION( Threshold          )
     REGISTER_FUNCTION( ThresholdDouble, Threshold )
 }

--- a/test/unit_tests/unit_test_image_function.cpp
+++ b/test/unit_tests/unit_test_image_function.cpp
@@ -1927,6 +1927,7 @@ namespace neon
     SET_FUNCTION_4_FORMS( Maximum )
     SET_FUNCTION_4_FORMS( Minimum )
     SET_FUNCTION_4_FORMS( Subtract )
+    SET_FUNCTION_2_FORMS( Sum )
     SET_FUNCTION_8_FORMS( Threshold )
 }
 #endif


### PR DESCRIPTION
PR for #106 all test unit_pass and performances are good. Here some screenshot ( I disabled a lot of test to avoid useless waiting ):

![2018-10-16-023658_1824x984_scrot](https://user-images.githubusercontent.com/16087328/46990696-1c48db80-d0f2-11e8-853e-6e9619056172.png)
![2018-10-16-024119_1824x984_scrot](https://user-images.githubusercontent.com/16087328/46990710-29fe6100-d0f2-11e8-9856-4884f52e09ce.png)

so the normal performance was: 0.16 sec / 0.70 sec / 2.8 sec / 11.12 sec
now the neon performance is:     0.04 sec / 0.17 sec / 1.1 sec / 3.691 sec
 