### PR TITLE
Move `cpu_identification` include to from `.h` to `.cpp` file.

### DIFF
--- a/src/image_function_simd.cpp
+++ b/src/image_function_simd.cpp
@@ -3,6 +3,7 @@
 #include "image_function.h"
 #include "image_function_helper.h"
 #include "parameter_validation.h"
+#include "penguinv/cpu_identification.h"
 
 #ifdef PENGUINV_AVX_SET
 #include <immintrin.h>

--- a/src/image_function_simd.h
+++ b/src/image_function_simd.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "image_buffer.h"
-#include "penguinv/cpu_identification.h"
 
 namespace Image_Function_Simd
 {


### PR DESCRIPTION
Addresses #149 