### PR TITLE
Some fixes for python example in Linux.

### DIFF
--- a/examples/python/bitmap_operation.py
+++ b/examples/python/bitmap_operation.py
@@ -6,7 +6,8 @@ Example of how to use python wrappers of penguinV to save a gray scale version o
 # to the places that python will look for the module.
 
 import sys
-sys.path.insert(0, '..\\..\\src\\python')
+import os
+sys.path.insert(0, os.path.join('..', '..', 'src', 'python'))
 
 # Now get the module.
 
@@ -43,7 +44,7 @@ def saveGrayScaleCopy(filenameToOpen, filenameToSave):
 
 try:
 
-    saveGrayScaleCopy( filenameToOpen = '..\\_image\\mercury.bmp', 
+    saveGrayScaleCopy( filenameToOpen = os.path.join('..', '_image', 'mercury.bmp'),
                        filenameToSave = 'result.bmp'
                      ) 
 

--- a/src/python/penguinV.i
+++ b/src/python/penguinV.i
@@ -5,9 +5,9 @@
 %include "std_vector.i"
 
 %{
-#include "..\image_buffer.h"
-#include "..\FileOperation\bitmap.h"
-#include "..\image_function.h"
+#include "../image_buffer.h"
+#include "../FileOperation/bitmap.h"
+#include "../image_function.h"
 %}
 
 %nodefaultctor PenguinV_Image::ImageTemplate;
@@ -60,8 +60,8 @@ namespace PenguinV_Image {
     // Type definitions aren't passed to wrapper code. We have to tell swig to generate the
     // template instance.
 
-    typedef ImageTemplate<uint8_t> Image; 
-    %template(Image) ImageTemplate<uint8_t>; 
+    typedef ImageTemplate<uint8_t> Image;
+    %template(Image) ImageTemplate<uint8_t>;
 
     const uint8_t GRAY_SCALE;
     const uint8_t RGB;
@@ -103,7 +103,7 @@ namespace Image_Function {
 
 }
 
-// For custom exceptions in ..\image_exception.h, it is easier to just manually redeclare the custom exceptions in python.
+// For custom exceptions in ../image_exception.h, it is easier to just manually redeclare the custom exceptions in python.
 
 %pythoncode %{
 
@@ -112,13 +112,13 @@ class PenguinV_Error(Exception):
     pass
 
 class ImageException(PenguinV_Error):
-    ''' Exceptions raised by image operations. 
+    ''' Exceptions raised by image operations.
     Attributes:
     expression - input expression in which the error occurred.
     message - explanation of the error.
     '''
     def __init__(self, expression, error):
         self.expression = expression
-        self.error = error 
+        self.error = error
 
-%} 
+%}

--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -1,13 +1,15 @@
 from distutils.core import Extension, setup
+import os
 
 module = Extension( '_penguinV', 
-                    sources = ['penguinV.i', 
-                               '..\\FileOperation\\bitmap.cpp',
-                               '..\\image_function.cpp',
-                               '..\\image_function_helper.cpp' # Need image_function_helper.cpp 
-                                                               # or we get linking errors. 
+                    sources = ['penguinV.i',
+                               os.path.join('..', 'FileOperation', 'bitmap.cpp'),
+                               os.path.join('..', 'image_function.cpp'),
+                               os.path.join('..', 'image_function_helper.cpp'),  # Need image_function_helper.cpp
+                                                                                 # or we get linking errors.
                               ],
-                    swig_opts = ['-c++'], language = 'c++'
+                    swig_opts = ['-c++'], language = 'c++',
+                    extra_compile_args=['-std=c++11']
                   )
 setup(name = 'penguinV',
       ext_modules = [module],


### PR DESCRIPTION
- Use os.path.join to support cross-platform paths.
- Windows supports forward slash in include paths, so changed paths to be compatible with Linux.