### PR TITLE
Fixed dependencies in makefiles in certain examples, issue #209

### DIFF
--- a/examples/bitmap_operation/README.md
+++ b/examples/bitmap_operation/README.md
@@ -5,7 +5,7 @@ Open example_bitmap_operation.vcxproj file in this directory to create solution 
 - g++    
 In this directory you need to type/paste this text in terminal:    
 	```bash
-	g++ -std=c++11 -Wall example_bitmap_operation.cpp ../../src/image_function_helper.cpp ../../src/image_function.cpp ../../src/FileOperation/bitmap.cpp -o application
+	g++ -std=c++11 -Wall example_bitmap_operation.cpp ../../src/image_function_helper.cpp ../../src/image_function.cpp ../../src/FileOperation/bitmap.cpp ../../src/penguinv/penguinv.cpp -o application
 	```
 
 - make    

--- a/examples/bitmap_operation/makefile
+++ b/examples/bitmap_operation/makefile
@@ -3,7 +3,7 @@
 ##
 CXXFLAGS += -std=c++11 -Wall -Wextra -Wstrict-aliasing -Wpedantic -Wconversion -O2 -march=native
 
-example_bitmap_operation : ../../src/image_function_helper.cpp ../../src/image_function.cpp ../../src/FileOperation/bitmap.cpp
+example_bitmap_operation : ../../src/image_function_helper.cpp ../../src/image_function.cpp ../../src/FileOperation/bitmap.cpp ../../src/penguinv/penguinv.cpp
 
 .PHONY: clean
 clean:

--- a/examples/blob_detection/README.md
+++ b/examples/blob_detection/README.md
@@ -5,7 +5,7 @@ Open example_blob_detection.vcxproj file in this directory to create solution fo
 - g++    
 In this directory you need to type/paste this text in terminal:    
 	```bash
-	g++ -std=c++11 -Wall example_blob_detection.cpp ../../src/math/math_base.cpp ../../src/image_function_helper.cpp ../../src/image_function.cpp ../../src/blob_detection.cpp ../../src/FileOperation/bitmap.cpp -o application
+	g++ -std=c++11 -Wall example_blob_detection.cpp ../../src/math/math_base.cpp ../../src/image_function_helper.cpp ../../src/image_function.cpp ../../src/blob_detection.cpp ../../src/FileOperation/bitmap.cpp ../../src/penguinv/penguinv.cpp -o application
 	```
 
 - make    

--- a/examples/blob_detection/makefile
+++ b/examples/blob_detection/makefile
@@ -3,7 +3,7 @@
 ##
 CXXFLAGS += -std=c++11 -Wall -Wextra -Wstrict-aliasing -Wpedantic -Wconversion -O2 -march=native
 
-example_blob_detection : ../../src/math/math_base.cpp ../../src/image_function_helper.cpp ../../src/image_function.cpp ../../src/blob_detection.cpp ../../src/FileOperation/bitmap.cpp
+example_blob_detection : ../../src/math/math_base.cpp ../../src/image_function_helper.cpp ../../src/image_function.cpp ../../src/blob_detection.cpp ../../src/FileOperation/bitmap.cpp ../../src/penguinv/penguinv.cpp ../../src/penguinv/penguinv.cpp
 
 .PHONY: clean
 clean:

--- a/examples/image_function/README.md
+++ b/examples/image_function/README.md
@@ -5,7 +5,7 @@ Open example_image_function.vcxproj file in this directory to create solution fo
 - g++    
 In this directory you need to type/paste this text in terminal:    
 	```bash
-	g++ -std=c++11 -Wall example_image_function.cpp ../../src/image_function_helper.cpp ../../src/image_function.cpp -o application
+	g++ -std=c++11 -Wall example_image_function.cpp ../../src/image_function_helper.cpp ../../src/image_function.cpp ../../src/penguinv/penguinv.cpp -o application
 	```
 
 - make    

--- a/examples/image_function/makefile
+++ b/examples/image_function/makefile
@@ -3,7 +3,7 @@
 ##
 CXXFLAGS += -std=c++11 -Wall -Wextra -Wstrict-aliasing -Wpedantic -Wconversion -O2 -march=native
 
-example_image_function : ../../src/image_function_helper.cpp ../../src/image_function.cpp
+example_image_function : ../../src/image_function_helper.cpp ../../src/image_function.cpp ../../src/penguinv/penguinv.cpp
 
 .PHONY: clean
 clean:

--- a/examples/thread_pool/README.md
+++ b/examples/thread_pool/README.md
@@ -5,7 +5,7 @@ Open example_thread_pool.vcxproj file in this directory to create solution for y
 - g++    
 In this directory you need to type/paste this text in terminal:    
 	```bash
-	g++ -std=c++11 -pthread -Wall example_thread_pool.cpp ../../src/image_function_helper.cpp ../../src/image_function.cpp ../../src/thread_pool.cpp -o application
+	g++ -std=c++11 -pthread -Wall example_thread_pool.cpp ../../src/image_function_helper.cpp ../../src/image_function.cpp ../../src/thread_pool.cpp ../../src/penguinv/penguinv.cpp -o application
 	```
 
 - make    

--- a/examples/thread_pool/makefile
+++ b/examples/thread_pool/makefile
@@ -4,7 +4,7 @@
 CXXFLAGS += -std=c++11 -Wall -Wextra -Wstrict-aliasing -Wpedantic -Wconversion -O2 -march=native
 LDFLAGS += -pthread
 
-example_thread_pool : ../../src/image_function_helper.cpp ../../src/image_function.cpp ../../src/thread_pool.cpp
+example_thread_pool : ../../src/image_function_helper.cpp ../../src/image_function.cpp ../../src/thread_pool.cpp ../../src/penguinv/penguinv.cpp
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Some entries were missing in following examples: bitmap_operation, blob_detection, image_function, example_thread_pool so linker gone wild. This one fixes #209 