### PR TITLE
Simplify unit test cmake file with environment variable support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
     - os: linux
       env: DYNAMIC_ANALYSIS=ON PENGUINV_UNIT_TEST_RUN_COUNT=10 CMAKE_OPTIONS="-DCMAKE_BUILD_TYPE=Debug"
       after_script:
-        - cat "${TRAVIS_BUILD_DIR}/build/Testing/Temporary/MemoryChecker.3.log" > out && cat out
+        - cat "${TRAVIS_BUILD_DIR}/build/Testing/Temporary/MemoryChecker.2.log" > out && cat out
         - test ! -s out
       addons:
         apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
     - os: linux
       env: STATIC_ANALYSIS=ON
     - os: linux
-      env: DYNAMIC_ANALYSIS=ON CMAKE_OPTIONS="-DCMAKE_BUILD_TYPE=Debug -DPENGUINV_ENABLE_VALGRIND_UNIT_TEST=ON"
+      env: DYNAMIC_ANALYSIS=ON UNIT_TEST_RUN_COUNT=10 CMAKE_OPTIONS="-DCMAKE_BUILD_TYPE=Debug -DPENGUINV_ENABLE_VALGRIND_UNIT_TEST=ON"
       after_script:
         - cat "${TRAVIS_BUILD_DIR}/build/Testing/Temporary/MemoryChecker.3.log" > out && cat out
         - test ! -s out
@@ -46,9 +46,9 @@ script:
       cmake .. ${CMAKE_OPTIONS}
       cmake --build .
       if [[ "$DYNAMIC_ANALYSIS" == "ON" ]]; then
-        ctest -R unit_test_valgrind --extra-verbose -T MemCheck # execute unit_test_valgrind
+        ctest -R unit_test --extra-verbose -T MemCheck # execute unit_test_valgrind
       else
-        ctest -E 'perf_test|unit_test_valgrind' --extra-verbose # execute unit_test and unit_test_opencl
+        ctest -E 'perf_test' --extra-verbose # execute unit_test and unit_test_opencl
       fi
     fi
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
     - os: linux
       env: STATIC_ANALYSIS=ON
     - os: linux
-      env: DYNAMIC_ANALYSIS=ON UNIT_TEST_RUN_COUNT=10 CMAKE_OPTIONS="-DCMAKE_BUILD_TYPE=Debug -DPENGUINV_ENABLE_VALGRIND_UNIT_TEST=ON"
+      env: DYNAMIC_ANALYSIS=ON PENGUINV_UNIT_TEST_RUN_COUNT=10 CMAKE_OPTIONS="-DCMAKE_BUILD_TYPE=Debug -DPENGUINV_ENABLE_VALGRIND_UNIT_TEST=ON"
       after_script:
         - cat "${TRAVIS_BUILD_DIR}/build/Testing/Temporary/MemoryChecker.3.log" > out && cat out
         - test ! -s out
@@ -46,7 +46,7 @@ script:
       cmake .. ${CMAKE_OPTIONS}
       cmake --build .
       if [[ "$DYNAMIC_ANALYSIS" == "ON" ]]; then
-        ctest -R unit_test --extra-verbose -T MemCheck # execute unit_test_valgrind
+        ctest -R unit_test --extra-verbose -T MemCheck # execute unit_test only
       else
         ctest -E 'perf_test' --extra-verbose # execute unit_test and unit_test_opencl
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
     - os: linux
       env: STATIC_ANALYSIS=ON
     - os: linux
-      env: DYNAMIC_ANALYSIS=ON PENGUINV_UNIT_TEST_RUN_COUNT=10 CMAKE_OPTIONS="-DCMAKE_BUILD_TYPE=Debug -DPENGUINV_ENABLE_VALGRIND_UNIT_TEST=ON"
+      env: DYNAMIC_ANALYSIS=ON PENGUINV_UNIT_TEST_RUN_COUNT=10 CMAKE_OPTIONS="-DCMAKE_BUILD_TYPE=Debug"
       after_script:
         - cat "${TRAVIS_BUILD_DIR}/build/Testing/Temporary/MemoryChecker.3.log" > out && cat out
         - test ! -s out

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ before_build:
   - cmd: call script\appveyor\cuda_install.cmd
 
 build_script:
-  - set UNIT_TEST_RUN_COUNT=500
+  - set PENGUINV_UNIT_TEST_RUN_COUNT=500
   - cmd: cd C:\projects\penguinv
   - cmd: md build
   - cmd: cd build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,6 +26,7 @@ before_build:
   - cmd: call script\appveyor\cuda_install.cmd
 
 build_script:
+  - set UNIT_TEST_RUN_COUNT=500
   - cmd: cd C:\projects\penguinv
   - cmd: md build
   - cmd: cd build

--- a/test/unit_tests/CMakeLists.txt
+++ b/test/unit_tests/CMakeLists.txt
@@ -62,7 +62,7 @@ target_link_libraries(unit_tests
                       PRIVATE unit_tests_options
                               unit_tests_warnings
                               Threads::Threads)
-add_test(NAME unit_test COMMAND unit_tests)
+add_test(NAME unit_test COMMAND unit_tests $ENV{UNIT_TEST_RUN_COUNT})
 
 option(PENGUINV_ENABLE_VALGRIND_UNIT_TEST "Execute Valgrind Unit Test" OFF)
 if(${PENGUINV_ENABLE_VALGRIND_UNIT_TEST})

--- a/test/unit_tests/CMakeLists.txt
+++ b/test/unit_tests/CMakeLists.txt
@@ -63,4 +63,4 @@ target_link_libraries(unit_tests
                               unit_tests_warnings
                               Threads::Threads)
 
-add_test(NAME unit_test COMMAND unit_tests $ENV{UNIT_TEST_RUN_COUNT})
+add_test(NAME unit_test COMMAND unit_tests $ENV{PENGUINV_UNIT_TEST_RUN_COUNT})

--- a/test/unit_tests/CMakeLists.txt
+++ b/test/unit_tests/CMakeLists.txt
@@ -63,8 +63,4 @@ target_link_libraries(unit_tests
                               unit_tests_warnings
                               Threads::Threads)
 add_test(NAME unit_test COMMAND unit_tests $ENV{UNIT_TEST_RUN_COUNT})
-
-option(PENGUINV_ENABLE_VALGRIND_UNIT_TEST "Execute Valgrind Unit Test" OFF)
-if(${PENGUINV_ENABLE_VALGRIND_UNIT_TEST})
-    add_test(NAME unit_test_valgrind COMMAND unit_tests 10)
 endif()

--- a/test/unit_tests/CMakeLists.txt
+++ b/test/unit_tests/CMakeLists.txt
@@ -62,5 +62,5 @@ target_link_libraries(unit_tests
                       PRIVATE unit_tests_options
                               unit_tests_warnings
                               Threads::Threads)
+
 add_test(NAME unit_test COMMAND unit_tests $ENV{UNIT_TEST_RUN_COUNT})
-endif()


### PR DESCRIPTION
We use an environment variable to set an input command line parameter for compiled `unit_tests` application. We set iteration count on unit tests to _500_ for **AppVeyor**.

Relates to #241 