### PR TITLE
AVX implementation of RgbToBgr() function

### DIFF
--- a/src/image_function_simd.cpp
+++ b/src/image_function_simd.cpp
@@ -390,6 +390,38 @@ namespace avx
         }
     }
 
+    void RgbToBgr( uint8_t * outY, const uint8_t * inY, const uint8_t * outYEnd, uint32_t rowSizeOut, uint32_t rowSizeIn, 
+                   const uint8_t colorCount, uint32_t simdWidth, uint32_t totalSimdWidth, uint32_t nonSimdWidth )
+    {
+        const simd ctrl = _mm256_setr_epi8(2, 1, 0, 5, 4, 3, 8, 7, 6, 11, 10, 9, 14, 13, 12, 15, 
+                                           16, 17, 20, 19, 18, 23, 22, 21, 26, 25, 24, 29, 28, 27, 30, 31);
+        for( ; outY != outYEnd; outY += rowSizeOut, inY += rowSizeIn ) {
+            const uint8_t * inX  = inY;
+            uint8_t       * outX = outY;
+
+            const uint8_t * outXEnd = outX + totalSimdWidth;
+
+            for( ; outX != outXEnd; outX += simdWidth, inX += simdWidth ) {
+                const simd * src = reinterpret_cast<const simd*> (inX);
+                simd * dst = reinterpret_cast<simd*> (outX);
+                simd result = _mm256_loadu_si256( src );
+                result = _mm256_shuffle_epi8( result, ctrl );
+                _mm256_storeu_si256( dst, result );
+                *(outX + 15) = *(inX + 17);
+                *(outX + 17) = *(inX + 15);
+            }
+
+            if( nonSimdWidth > 0 ) {
+                const uint8_t * outXEndNonSimd = outXEnd + nonSimdWidth;
+                for( ; outX != outXEndNonSimd; outX += colorCount, inX += colorCount ) {
+                    *(outX + 2) = *(inX);
+                    *(outX + 1) = *(inX + 1);
+                    *(outX) = *(inX + 2);
+                }
+            }
+        }
+    }
+
     void Subtract( uint32_t rowSizeIn1, uint32_t rowSizeIn2, uint32_t rowSizeOut, const uint8_t * in1Y, const uint8_t * in2Y,
                    uint8_t * outY, const uint8_t * outYEnd, uint32_t simdWidth, uint32_t totalSimdWidth, uint32_t nonSimdWidth )
     {
@@ -2072,7 +2104,7 @@ if ( simdType == neon_function ) { \
 
         const uint8_t colorCount = RGB;
 
-        if( (simdType == cpu_function) || (simdType == avx_function) || ((width * colorCount) < simdSize) ) {
+        if( (simdType == cpu_function) || ((width * colorCount) < simdSize) ) {
             AVX_CODE( RgbToBgr( in, startXIn, startYIn, out, startXOut, startYOut, width, height, sse_function ); )
 
             Image_Function::RgbToBgr( in, startXIn, startYIn, out, startXOut, startYOut, width, height );
@@ -2103,6 +2135,7 @@ if ( simdType == neon_function ) { \
             nonSimdWidth += rgbSimdSize;
         }
 
+        AVX_CODE( avx::RgbToBgr( outY, inY, outYEnd, rowSizeOut, rowSizeIn, colorCount, rgbSimdSize, totalSimdWidth, nonSimdWidth ); )
         SSE_CODE( sse::RgbToBgr( outY, inY, outYEnd, rowSizeOut, rowSizeIn, colorCount, rgbSimdSize, totalSimdWidth, nonSimdWidth ); )
         NEON_CODE( neon::RgbToBgr( outY, inY, outYEnd, rowSizeOut, rowSizeIn, colorCount, rgbSimdSize, totalSimdWidth, nonSimdWidth ); )
     }

--- a/test/performance_tests/performance_test_image_function.cpp
+++ b/test/performance_tests/performance_test_image_function.cpp
@@ -356,6 +356,7 @@ namespace image_function_avx
     SET_FUNCTION( Maximum            )
     SET_FUNCTION( Minimum            )
     SET_FUNCTION( ProjectionProfile  )
+    SET_FUNCTION( RgbToBgr           )
     SET_FUNCTION( Subtract           )
     SET_FUNCTION( Sum                )
     SET_FUNCTION( Threshold          )

--- a/test/unit_tests/unit_test_image_function.cpp
+++ b/test/unit_tests/unit_test_image_function.cpp
@@ -2113,6 +2113,7 @@ namespace avx
     SET_FUNCTION_4_FORMS( Maximum )
     SET_FUNCTION_4_FORMS( Minimum )
     SET_FUNCTION_4_FORMS( ProjectionProfile )
+    SET_FUNCTION_4_FORMS( RgbToBgr )
     SET_FUNCTION_4_FORMS( Subtract )
     SET_FUNCTION_2_FORMS( Sum )
     SET_FUNCTION_8_FORMS( Threshold )


### PR DESCRIPTION
PR for #117 
I found a way to implement it in AVX, it's not more performant, but it should avoid SSE/AVX switching penalties:

![screenshot_20190126_124630](https://user-images.githubusercontent.com/16087328/51791046-48510f80-216b-11e9-833e-718c5a2c825d.png)
