### PR TITLE
Add missing function registration for ConvertToRgb SIMD function

### DIFF
--- a/src/image_function_simd.cpp
+++ b/src/image_function_simd.cpp
@@ -31,6 +31,7 @@ namespace
             table.BitwiseAnd         = &Image_Function_Simd::BitwiseAnd;
             table.BitwiseOr          = &Image_Function_Simd::BitwiseOr;
             table.BitwiseXor         = &Image_Function_Simd::BitwiseXor;
+            table.ConvertToRgb       = &Image_Function_Simd::ConvertToRgb;
             table.Invert             = &Image_Function_Simd::Invert;
             table.Maximum            = &Image_Function_Simd::Maximum;
             table.Minimum            = &Image_Function_Simd::Minimum;


### PR DESCRIPTION
PR for #358. here's the performance on SSE:

![screenshot_20190128_091109](https://user-images.githubusercontent.com/16087328/51841886-a00f8800-22dd-11e9-8874-13d748ddce8e.png)

I'm gonna upload the result for NEON later when I'm gonna have access to my pi.