### PR TITLE
Add oval and rectangle drawing support for UI Window Qt class

### DIFF
--- a/src/ui/qt/qt_ui.cpp
+++ b/src/ui/qt/qt_ui.cpp
@@ -45,13 +45,11 @@ void UiWindowQt::drawLine( const Point2d & start, const Point2d & end, const Pai
     _display();
 }
 
-void UiWindowQt::drawEllipse( const Point2d & center, double xDiameter, double yDiameter, const PaintColor & color )
+void UiWindowQt::drawEllipse( const Point2d & center, double xRadius, double yRadius, const PaintColor & color )
 {
     QPainter paint( &_pixmap );
     paint.setPen( QColor( color.red, color.green, color.blue, color.alpha ) );
-    paint.drawEllipse( static_cast<int>(center.x - (xDiameter / 2)), static_cast<int>(center.y - (yDiameter / 2)),
-                       static_cast<int>(xDiameter), static_cast<int>(yDiameter) );
-
+    paint.drawEllipse( QPointF(center.x, center.y), xRadius, yRadius );
     _window.setPixmap( _pixmap );
     _display();
 }

--- a/src/ui/qt/qt_ui.cpp
+++ b/src/ui/qt/qt_ui.cpp
@@ -45,21 +45,21 @@ void UiWindowQt::drawLine( const Point2d & start, const Point2d & end, const Pai
     _display();
 }
 
-void UiWindowQt::drawEllipse(const Point2d & center, const int xDiameter, const int yDiameter, const PaintColor &color)
+void UiWindowQt::drawEllipse(const Point2d & center, double xDiameter, double yDiameter, const PaintColor &color)
 {
     QPainter paint( &_pixmap );
     paint.setPen( QColor( color.red, color.green, color.blue, color.alpha ) );
-    paint.drawEllipse(static_cast<int>(center.x)-(xDiameter/2),static_cast<int>(center.y)-(yDiameter/2),xDiameter,yDiameter);
+    paint.drawEllipse(static_cast<int>((center.x)-(xDiameter/2)),static_cast<int>((center.y)-(yDiameter/2)),static_cast<int>(xDiameter),static_cast<int>(yDiameter));
 
     _window.setPixmap( _pixmap );
     _display();
 }
 
-void UiWindowQt::drawRectangle(const Point2d & start, const int width, const int height, const PaintColor &color)
+void UiWindowQt::drawRectangle(const Point2d & topLeftCorner, double width, double height, const PaintColor &color)
 {
     QPainter paint( &_pixmap );
     paint.setPen( QColor( color.red, color.green, color.blue, color.alpha ) );
-    paint.drawRect(static_cast<int>(start.x),static_cast<int>(start.y),width,height);
+    paint.drawRect(static_cast<int>(topLeftCorner.x),static_cast<int>(topLeftCorner.y),static_cast<int>(width),static_cast<int>(height));
 
     _window.setPixmap( _pixmap );
     _display();

--- a/src/ui/qt/qt_ui.cpp
+++ b/src/ui/qt/qt_ui.cpp
@@ -45,21 +45,23 @@ void UiWindowQt::drawLine( const Point2d & start, const Point2d & end, const Pai
     _display();
 }
 
-void UiWindowQt::drawEllipse(const Point2d & center, double xDiameter, double yDiameter, const PaintColor &color)
+void UiWindowQt::drawEllipse( const Point2d & center, double xDiameter, double yDiameter, const PaintColor & color )
 {
     QPainter paint( &_pixmap );
     paint.setPen( QColor( color.red, color.green, color.blue, color.alpha ) );
-    paint.drawEllipse(static_cast<int>((center.x)-(xDiameter/2)),static_cast<int>((center.y)-(yDiameter/2)),static_cast<int>(xDiameter),static_cast<int>(yDiameter));
+    paint.drawEllipse( static_cast<int>(center.x - (xDiameter / 2)), static_cast<int>(center.y - (yDiameter / 2)),
+                       static_cast<int>(xDiameter), static_cast<int>(yDiameter) );
 
     _window.setPixmap( _pixmap );
     _display();
 }
 
-void UiWindowQt::drawRectangle(const Point2d & topLeftCorner, double width, double height, const PaintColor &color)
+void UiWindowQt::drawRectangle( const Point2d & topLeftCorner, double width, double height, const PaintColor & color )
 {
     QPainter paint( &_pixmap );
     paint.setPen( QColor( color.red, color.green, color.blue, color.alpha ) );
-    paint.drawRect(static_cast<int>(topLeftCorner.x),static_cast<int>(topLeftCorner.y),static_cast<int>(width),static_cast<int>(height));
+    paint.drawRect( static_cast<int>(topLeftCorner.x), static_cast<int>(topLeftCorner.y),
+                    static_cast<int>(width), static_cast<int>(height) );
 
     _window.setPixmap( _pixmap );
     _display();

--- a/src/ui/qt/qt_ui.cpp
+++ b/src/ui/qt/qt_ui.cpp
@@ -44,3 +44,23 @@ void UiWindowQt::drawLine( const Point2d & start, const Point2d & end, const Pai
     _window.setPixmap( _pixmap );
     _display();
 }
+
+void UiWindowQt::drawEllipse(const Point2d & center, const int xDiameter, const int yDiameter, const PaintColor &color)
+{
+    QPainter paint( &_pixmap );
+    paint.setPen( QColor( color.red, color.green, color.blue, color.alpha ) );
+    paint.drawEllipse(static_cast<int>(center.x)-(xDiameter/2),static_cast<int>(center.y)-(yDiameter/2),xDiameter,yDiameter);
+
+    _window.setPixmap( _pixmap );
+    _display();
+}
+
+void UiWindowQt::drawRectangle(const Point2d & start, const int width, const int height, const PaintColor &color)
+{
+    QPainter paint( &_pixmap );
+    paint.setPen( QColor( color.red, color.green, color.blue, color.alpha ) );
+    paint.drawRect(static_cast<int>(start.x),static_cast<int>(start.y),width,height);
+
+    _window.setPixmap( _pixmap );
+    _display();
+}

--- a/src/ui/qt/qt_ui.h
+++ b/src/ui/qt/qt_ui.h
@@ -12,8 +12,8 @@ public:
 
     virtual void drawPoint( const Point2d & point, const PaintColor & color );
     virtual void drawLine( const Point2d & start, const Point2d & end, const PaintColor & color );
-    virtual void drawEllipse(const Point2d & center, const int xDiameter, const int yDiameter, const PaintColor & color);
-    virtual void drawRectangle(const Point2d & start, const int width, const int height, const PaintColor & color);
+    virtual void drawEllipse(const Point2d & center, double xDiameter, double yDiameter, const PaintColor & color);
+    virtual void drawRectangle(const Point2d & topLeftCorner, double width, double height, const PaintColor & color);
 protected:
     virtual void _display();
 private:

--- a/src/ui/qt/qt_ui.h
+++ b/src/ui/qt/qt_ui.h
@@ -12,6 +12,8 @@ public:
 
     virtual void drawPoint( const Point2d & point, const PaintColor & color );
     virtual void drawLine( const Point2d & start, const Point2d & end, const PaintColor & color );
+    virtual void drawEllipse(const Point2d & center, const int xDiameter, const int yDiameter, const PaintColor & color);
+    virtual void drawRectangle(const Point2d & start, const int width, const int height, const PaintColor & color);
 protected:
     virtual void _display();
 private:

--- a/src/ui/qt/qt_ui.h
+++ b/src/ui/qt/qt_ui.h
@@ -12,8 +12,8 @@ public:
 
     virtual void drawPoint( const Point2d & point, const PaintColor & color );
     virtual void drawLine( const Point2d & start, const Point2d & end, const PaintColor & color );
-    virtual void drawEllipse(const Point2d & center, double xDiameter, double yDiameter, const PaintColor & color);
-    virtual void drawRectangle(const Point2d & topLeftCorner, double width, double height, const PaintColor & color);
+    virtual void drawEllipse( const Point2d & center, double xRadius, double yRadius, const PaintColor & color );
+    virtual void drawRectangle( const Point2d & topLeftCorner, double width, double height, const PaintColor & color );
 protected:
     virtual void _display();
 private:

--- a/src/ui/ui.cpp
+++ b/src/ui/ui.cpp
@@ -33,6 +33,16 @@ void UiWindow::drawLine( const Point2d &, const Point2d &, const PaintColor & )
     _display();
 }
 
+void UiWindow::drawEllipse( const Point2d &, double, double, const PaintColor & )
+{
+    _display();
+}
+
+void UiWindow::drawRectangle( const Point2d &, double, double, const PaintColor & )
+{
+    _display();
+}
+
 void UiWindow::_display()
 {
 }

--- a/src/ui/ui.h
+++ b/src/ui/ui.h
@@ -28,8 +28,8 @@ public:
     virtual void setImage( const PenguinV_Image::Image & image ); // replaces existing shown image by new image
     virtual void drawPoint( const Point2d & point, const PaintColor & color );
     virtual void drawLine( const Point2d & start, const Point2d & end, const PaintColor & color );
-    virtual void drawEllipse(const Point2d & center, double xDiameter, double yDiameter, const PaintColor & color);
-    virtual void drawRectangle(const Point2d & topLeftCorner, double width, double height, const PaintColor & color);
+    virtual void drawEllipse( const Point2d & center, double xRadius, double yRadius, const PaintColor & color );
+    virtual void drawRectangle( const Point2d & topLeftCorner, double width, double height, const PaintColor & color );
 protected:
     virtual void _display();
 

--- a/src/ui/ui.h
+++ b/src/ui/ui.h
@@ -28,6 +28,8 @@ public:
     virtual void setImage( const PenguinV_Image::Image & image ); // replaces existing shown image by new image
     virtual void drawPoint( const Point2d & point, const PaintColor & color );
     virtual void drawLine( const Point2d & start, const Point2d & end, const PaintColor & color );
+    virtual void drawEllipse(const Point2d & center, double xDiameter, double yDiameter, const PaintColor & color);
+    virtual void drawRectangle(const Point2d & topLeftCorner, double width, double height, const PaintColor & color);
 protected:
     virtual void _display();
 


### PR DESCRIPTION
**`drawEllipse` function** - implemented from `QPainter::drawEllipse( int x,int y,int w, int h)` which refers to a rectangle with starting point (x,y), width w, and height h)
**Parameters:**
`Point2D center` - starting point referring to center of ellipse.
`int xDiameter` - Diameter in x axis, 
`int yDiameter `- Diameter in y axis
`PaintColor color` - color of drawn ellipse

**`drawRectangle` function**
**Parameters:**
`Point2D start` - starting point referring to upper left point of rectangle.
`int width` - width from starting point to its right direction.
`int height` - height from starting point to its bottom direction.
`PaintColor color` - color of drawn rectangle

Related to Issue #282 