### PR TITLE
Add unit tests for few functions

### DIFF
--- a/src/filtering.cpp
+++ b/src/filtering.cpp
@@ -12,23 +12,15 @@ namespace
     struct FilterKernel
     {
         explicit FilterKernel(float multiplier_)
-            : multiplier( multiplier_ )
         {
             const uint32_t size = 256u * sizeInBytes;
             for ( uint32_t i = 0; i < size; ++i ) {
-                for ( uint32_t j = i; j < size; ++j ) {
-                    kernel[i][j] = kernel[j][i] = gradient( i, j );
-                }
+                for ( uint32_t j = i; j < size; ++j )
+                    kernel[i][j] = kernel[j][i] = static_cast<uint8_t>(sqrtf( static_cast<float>(i * i + j * j) ) * multiplier_ + 0.5f);
             }
         }
 
-        uint8_t gradient(uint32_t gX, uint32_t gY) const
-        {
-            return static_cast<uint8_t>(sqrtf( static_cast<float>(gX * gX + gY * gY) ) * multiplier + 0.5f);
-        }
-
         uint8_t kernel[256u * sizeInBytes][256u * sizeInBytes];
-        const float multiplier;
     };
 }
 

--- a/src/image_function.cpp
+++ b/src/image_function.cpp
@@ -1487,6 +1487,11 @@ namespace Image_Function
         }
     }
 
+    Image Rotate( const Image & in, double centerX, double centerY, double angle )
+    {
+        return Image_Function_Helper::Rotate( Rotate, in, centerX, centerY, angle );
+    }
+
     void Rotate( const Image & in, double centerXIn, double centerYIn, Image & out, double centerXOut, double centerYOut, double angle )
     {
         ParameterValidation( in, out );

--- a/src/image_function.h
+++ b/src/image_function.h
@@ -191,7 +191,8 @@ namespace Image_Function
     void  RgbToBgr( const Image & in, uint32_t startXIn, uint32_t startYIn, Image & out, uint32_t startXOut, uint32_t startYOut,
                     uint32_t width, uint32_t height );
 
-    void Rotate( const Image & in, double centerXIn, double centerYIn, Image & out, double centerXOut, double centerYOut, double angle );
+    Image Rotate( const Image & in, double centerX, double centerY, double angle );
+    void  Rotate( const Image & in, double centerXIn, double centerYIn, Image & out, double centerXOut, double centerYOut, double angle );
 
     void SetPixel( Image & image, uint32_t x, uint32_t y, uint8_t value );
     void SetPixel( Image & image, const std::vector < uint32_t > & X, const std::vector < uint32_t > & Y, uint8_t value );

--- a/src/image_function_helper.cpp
+++ b/src/image_function_helper.cpp
@@ -765,6 +765,17 @@ namespace Image_Function_Helper
         return out;
     }
 
+    Image Rotate( FunctionTable::RotateForm2 rotate,
+                  const Image & in, double centerX, double centerY, double angle )
+    {
+        Image_Function::ParameterValidation( in );
+        Image out = in.generate( in.width(), in.height() );
+
+        rotate( in, centerX, centerY, out, centerX, centerY, angle );
+
+        return out;
+    }
+
     Image Shift( FunctionTable::ShiftForm4 shift,
                  const Image & in, double shiftX, double shiftY )
     {

--- a/src/image_function_helper.h
+++ b/src/image_function_helper.h
@@ -174,7 +174,8 @@ namespace Image_Function_Helper
         typedef void  (*RgbToBgrForm4)( const Image & in, uint32_t startXIn, uint32_t startYIn, Image & out, uint32_t startXOut, uint32_t startYOut,
                                         uint32_t width, uint32_t height );
 
-        typedef void (*Rotate)( const Image & in, double centerXIn, double centerYIn, Image & out, double centerXOut, double centerYOut, double angle );
+        typedef Image (*RotateForm1)( const Image & in, double centerX, double centerY, double angle );
+        typedef void  (*RotateForm2)( const Image & in, double centerXIn, double centerYIn, Image & out, double centerXOut, double centerYOut, double angle );
 
         typedef void (*SetPixelForm1)( Image & image, uint32_t x, uint32_t y, uint8_t value );
         typedef void (*SetPixelForm2)( Image & image, const std::vector < uint32_t > & X, const std::vector < uint32_t > & Y, uint8_t value );
@@ -431,6 +432,9 @@ namespace Image_Function_Helper
 
     Image RgbToBgr( FunctionTable::RgbToBgrForm4 rgbToBgr,
                     const Image & in, uint32_t startXIn, uint32_t startYIn, uint32_t width, uint32_t height );
+
+    Image Rotate( FunctionTable::RotateForm2 rotate,
+                  const Image & in, double centerX, double centerY, double angle );
 
     Image Shift( FunctionTable::ShiftForm4 shift,
                  const Image & in, double shiftX, double shiftY );

--- a/test/unit_tests/unit_test_image_function.cpp
+++ b/test/unit_tests/unit_test_image_function.cpp
@@ -528,6 +528,72 @@ namespace Function_Template
         return verifyImage( image[1], roiX[1], roiY[1], roiWidth, roiHeight, intensity[0] );
     }
 
+    bool form1_ExtractChannel(ExtractChannelForm1 ExtractChannel)
+    {
+        const std::vector < uint8_t > intensity = intensityArray( 3 );
+        PenguinV_Image::Image input = uniformRGBImage( intensity[0] );
+        fillImage( input, 0, 0, input.width(), input.height(), intensity );
+
+        const uint8_t channelId = randomValue<uint8_t>( 3 );
+
+        const PenguinV_Image::Image output = ExtractChannel( input, channelId );
+
+        return verifyImage( output, intensity[channelId] ) && (output.colorCount() == PenguinV_Image::GRAY_SCALE);
+    }
+
+    bool form2_ExtractChannel(ExtractChannelForm2 ExtractChannel)
+    {
+        const std::vector < uint8_t > intensity = intensityArray( 3 );
+        PenguinV_Image::Image input = uniformRGBImage( intensity[0] );
+        fillImage( input, 0, 0, input.width(), input.height(), intensity );
+
+        const uint8_t channelId = randomValue<uint8_t>( 3 );
+        PenguinV_Image::Image output = uniformImage( input.width(), input.height() );
+
+        ExtractChannel( input, output, channelId );
+
+        return verifyImage( output, intensity[channelId] ) && (output.colorCount() == PenguinV_Image::GRAY_SCALE);
+    }
+
+    bool form3_ExtractChannel(ExtractChannelForm3 ExtractChannel)
+    {
+        const std::vector < uint8_t > intensity = intensityArray( 3 );
+        PenguinV_Image::Image input = uniformRGBImage( intensity[0] );
+        fillImage( input, 0, 0, input.width(), input.height(), intensity );
+
+        const uint8_t channelId = randomValue<uint8_t>( 3 );
+
+        uint32_t roiX, roiY;
+        uint32_t roiWidth, roiHeight;
+        generateRoi( input, roiX, roiY, roiWidth, roiHeight );
+
+        const PenguinV_Image::Image output = ExtractChannel( input, roiX, roiY, roiWidth, roiHeight, channelId );
+
+        return verifyImage( output, intensity[channelId] ) && equalSize( output, roiWidth, roiHeight ) && (output.colorCount() == PenguinV_Image::GRAY_SCALE);
+    }
+
+    bool form4_ExtractChannel(ExtractChannelForm4 ExtractChannel)
+    {
+        const std::vector < uint8_t > intensity = intensityArray( 3 );
+        PenguinV_Image::Image input = uniformRGBImage( intensity[0] );
+        fillImage( input, 0, 0, input.width(), input.height(), intensity );
+
+        const uint8_t channelId = randomValue<uint8_t>( 3 );
+        PenguinV_Image::Image output = uniformImage();
+
+        std::vector < std::pair <uint32_t, uint32_t> > size( 2 );
+        size[0] = imageSize( input );
+        size[1] = imageSize( output );
+
+        std::vector < uint32_t > roiX, roiY;
+        uint32_t roiWidth, roiHeight;
+        generateRoi( size, roiX, roiY, roiWidth, roiHeight );
+
+        ExtractChannel( input, roiX[0], roiY[0], output, roiX[1], roiY[1], roiWidth, roiHeight, channelId );
+
+        return verifyImage( output, roiX[3], roiY[3], roiWidth, roiHeight, intensity[channelId] );
+    }
+
     bool form1_Fill(FillForm1 Fill)
     {
         const std::vector < uint8_t > intensity = intensityArray( 2 );
@@ -1166,6 +1232,76 @@ namespace Function_Template
                           intensity[0] > intensity[1] ? intensity[0] : intensity[1] );
     }
 
+    bool form1_Merge(MergeForm1 Merge)
+    {
+        const std::vector < uint8_t > intensity = intensityArray( 3 );
+        std::vector < PenguinV_Image::Image > input = uniformImages( intensity );
+
+        const PenguinV_Image::Image output = Merge( input[0], input[1], input[2] );
+
+        return verifyImage( output, intensity, false ) && equalSize( output, input[0].width(), input[0].height() ) && (output.colorCount() == PenguinV_Image::RGB);
+    }
+
+    bool form2_Merge(MergeForm2 Merge)
+    {
+        const std::vector < uint8_t > intensity = intensityArray( 3 );
+        std::vector < PenguinV_Image::Image > input = uniformImages( intensity );
+        PenguinV_Image::Image output( input[0].width(), input[0].height(), PenguinV_Image::RGB ); 
+
+        Merge( input[0], input[1], input[2], output );
+
+        return verifyImage( output, intensity, false ) && (output.colorCount() == PenguinV_Image::RGB);
+    }
+
+    bool form3_Merge(MergeForm3 Merge)
+    {
+        const std::vector < uint8_t > intensity = intensityArray( 3 );
+        std::vector < PenguinV_Image::Image > input;
+        std::for_each( intensity.begin(), intensity.end(), [&]( uint8_t value )
+        { input.push_back( uniformImage( value ) ); } );
+
+        std::vector < std::pair <uint32_t, uint32_t> > size( 3 );
+        size[0] = imageSize( input[0] );
+        size[1] = imageSize( input[1] );
+        size[2] = imageSize( input[2] );
+
+        std::vector < uint32_t > roiX, roiY;
+        uint32_t roiWidth, roiHeight;
+        generateRoi( size, roiX, roiY, roiWidth, roiHeight );
+
+        const uint8_t channelId = randomValue<uint8_t>( 3 );
+
+        const PenguinV_Image::Image output = Merge( input[0], roiX[0], roiY[0], input[1], roiX[1], roiY[1], input[2], roiX[2], roiY[2], roiWidth, roiHeight );
+
+        return verifyImage( output, intensity, false ) && equalSize( output, roiWidth, roiHeight ) && (output.colorCount() == PenguinV_Image::RGB);
+    }
+
+    bool form4_Merge(MergeForm4 Merge)
+    {
+        const std::vector < uint8_t > intensity = intensityArray( 3 );
+        std::vector < PenguinV_Image::Image > input;
+        std::for_each( intensity.begin(), intensity.end(), [&]( uint8_t value )
+        { input.push_back( uniformImage( value ) ); } );
+
+        PenguinV_Image::Image output = uniformRGBImage( intensityValue() );
+
+        std::vector < std::pair <uint32_t, uint32_t> > size( 4 );
+        size[0] = imageSize( input[0] );
+        size[1] = imageSize( input[1] );
+        size[2] = imageSize( input[2] );
+        size[3] = imageSize( output );
+
+        std::vector < uint32_t > roiX, roiY;
+        uint32_t roiWidth, roiHeight;
+        generateRoi( size, roiX, roiY, roiWidth, roiHeight );
+
+        const uint8_t channelId = randomValue<uint8_t>( 3 );
+
+        Merge( input[0], roiX[0], roiY[0], input[1], roiX[1], roiY[1], input[2], roiX[2], roiY[2], output, roiX[3], roiY[3], roiWidth, roiHeight );
+
+        return verifyImage( output, roiX[3], roiY[3], roiWidth, roiHeight, intensity, false );
+    }
+
     bool form1_Minimum(MinimumForm1 Minimum)
     {
         const std::vector < uint8_t > intensity = intensityArray( 2 );
@@ -1413,7 +1549,7 @@ namespace Function_Template
     bool form2_ReplaceChannel(ReplaceChannelForm2 ReplaceChannel)
     {
         const std::vector < uint8_t > intensity = intensityArray( 2 );
-        const PenguinV_Image::Image input  = uniformImage   ( intensity[0] );
+        const PenguinV_Image::Image input = uniformImage( intensity[0] );
         PenguinV_Image::Image output = uniformRGBImage( intensity[1] );
 
         std::vector < std::pair <uint32_t, uint32_t> > size( 2 );
@@ -1652,6 +1788,50 @@ namespace Function_Template
         Shift( image[0], roiX[0], roiY[0], image[1], roiX[1], roiY[1], roiWidth, roiHeight, shiftX, shiftY );
 
         return verifyImage( image[1], roiX[1], roiY[1], roiWidth, roiHeight, intensity[0] );
+    }
+
+    bool form1_Split(SplitForm1 Split)
+    {
+        const std::vector < uint8_t > intensity = intensityArray( 3 );
+        PenguinV_Image::Image input = uniformRGBImage( intensity[0] );
+        fillImage( input, 0, 0, input.width(), input.height(), intensity );
+
+        std::vector < PenguinV_Image::Image > output = uniformImages( 3, input.width(), input.height() );
+        Split( input, output[0], output[1], output[2] );
+
+        return verifyImage( output[0], intensity[0] ) && verifyImage( output[1], intensity[1] ) && verifyImage( output[2], intensity[2] );
+    }
+
+    bool form2_Split(SplitForm2 Split)
+    {
+        const std::vector < uint8_t > inputIntensity = intensityArray( 3 );
+        PenguinV_Image::Image input = uniformRGBImage( inputIntensity[0] );
+        fillImage( input, 0, 0, input.width(), input.height(), inputIntensity );
+
+        const std::vector < uint8_t > outputIntensity = intensityArray( 3 );
+        std::vector < PenguinV_Image::Image > output;
+
+        std::for_each( outputIntensity.begin(), outputIntensity.end(), [&]( uint8_t value )
+        { output.push_back( uniformImage( value ) ); } );
+
+        std::vector < std::pair <uint32_t, uint32_t> > size( 4 );
+
+        size[0] = imageSize( input );
+        size[1] = imageSize( output[0] );
+        size[2] = imageSize( output[1] );
+        size[3] = imageSize( output[2] );
+
+        std::vector < uint32_t > roiX, roiY;
+        uint32_t roiWidth, roiHeight;
+        generateRoi( size, roiX, roiY, roiWidth, roiHeight );
+
+        const uint8_t channelId = randomValue<uint8_t>( 3 );
+
+        Split( input, roiX[0], roiY[0], output[0], roiX[1], roiY[1], output[1], roiX[2], roiY[2], output[2], roiX[3], roiY[3], roiWidth, roiHeight );
+
+        return verifyImage( output[0], roiX[1], roiY[1], roiWidth, roiHeight, inputIntensity[0] ) &&
+               verifyImage( output[1], roiX[2], roiY[2], roiWidth, roiHeight, inputIntensity[1] ) &&
+               verifyImage( output[2], roiX[3], roiY[3], roiWidth, roiHeight, inputIntensity[2] );
     }
 
     bool form1_Subtract(SubtractForm1 Subtract)
@@ -2087,6 +2267,7 @@ namespace image_function
     SET_FUNCTION_4_FORMS( ConvertToGrayScale )
     SET_FUNCTION_4_FORMS( ConvertToRgb )
     SET_FUNCTION_3_FORMS( Copy )
+    SET_FUNCTION_4_FORMS( ExtractChannel )
     SET_FUNCTION_2_FORMS( Fill )
     SET_FUNCTION_4_FORMS( Flip )
     SET_FUNCTION_4_FORMS( GammaCorrection )
@@ -2096,6 +2277,7 @@ namespace image_function
     SET_FUNCTION_2_FORMS( IsEqual )
     SET_FUNCTION_4_FORMS( LookupTable )
     SET_FUNCTION_4_FORMS( Maximum )
+    SET_FUNCTION_4_FORMS( Merge )
     SET_FUNCTION_4_FORMS( Minimum )
     SET_FUNCTION_4_FORMS( Normalize )
     SET_FUNCTION_4_FORMS( ProjectionProfile )
@@ -2103,6 +2285,7 @@ namespace image_function
     SET_FUNCTION_4_FORMS( Resize )
     SET_FUNCTION_4_FORMS( RgbToBgr )
     SET_FUNCTION_2_FORMS( SetPixel )
+    SET_FUNCTION_2_FORMS( Split )
     SET_FUNCTION_4_FORMS( Subtract )
     SET_FUNCTION_2_FORMS( Sum )
     SET_FUNCTION_8_FORMS( Threshold )

--- a/test/unit_tests/unit_test_image_function.cpp
+++ b/test/unit_tests/unit_test_image_function.cpp
@@ -591,7 +591,7 @@ namespace Function_Template
 
         ExtractChannel( input, roiX[0], roiY[0], output, roiX[1], roiY[1], roiWidth, roiHeight, channelId );
 
-        return verifyImage( output, roiX[3], roiY[3], roiWidth, roiHeight, intensity[channelId] );
+        return verifyImage( output, roiX[1], roiY[1], roiWidth, roiHeight, intensity[channelId] );
     }
 
     bool form1_Fill(FillForm1 Fill)


### PR DESCRIPTION
- add unit tests for **ExtractChannel**() function
- add unit tests for **Merge**() function
- add unit tests for **Split**() function
- simplify **filterKernel** structure
- add an extra form of **Rotate**() function

relates to #265 , #429, #366, #367, #373 