### PR TITLE
Issue-458: Set mfpu=neon-vfpv4 as CMake compile option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,10 @@ if(CUDA_FOUND)
     endif()
 endif()
 
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(arm.*|ARM.*)")
+    add_compile_options(-mfpu=neon-vfpv4)
+endif()
+
 option(PENGUINV_BUILD_TEST "Build tests of penguinV" ON)
 if(${PENGUINV_BUILD_TEST} AND (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR))
     enable_testing()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ if(CUDA_FOUND)
     endif()
 endif()
 
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(arm.*|ARM.*)")
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(arm*|ARM*)")
     add_compile_options(-mfpu=neon-vfpv4)
 endif()
 


### PR DESCRIPTION
With CMake there is no proper way to differentiate between Linux flavors. Nevertheless, I think the flag is only relevant for ARM targets. Therefore the provided fix should help. @0x72D0 Would you mind to test?