### PR TITLE
Disable check for a comment at the end of namespace during static analysis

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -40,7 +40,7 @@ ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
 DerivePointerAlignment: false
-FixNamespaceComments: true
+FixNamespaceComments: false
 IndentCaseLabels: false
 IndentWidth: 4
 IndentWrappedFunctionNames: true

--- a/src/image_function.h
+++ b/src/image_function.h
@@ -251,3 +251,13 @@ namespace Image_Function
     void  Transpose( const Image & in, uint32_t startXIn, uint32_t startYIn, Image & out, uint32_t startXOut, uint32_t startYOut,
                      uint32_t width, uint32_t height );
 }
+
+namespace TestNamespace1
+{
+
+}
+
+namespace TestNamespace2
+{
+
+} // TestNamespace2

--- a/src/image_function.h
+++ b/src/image_function.h
@@ -251,13 +251,3 @@ namespace Image_Function
     void  Transpose( const Image & in, uint32_t startXIn, uint32_t startYIn, Image & out, uint32_t startXOut, uint32_t startYOut,
                      uint32_t width, uint32_t height );
 }
-
-namespace TestNamespace1
-{
-
-}
-
-namespace TestNamespace2
-{
-
-} // TestNamespace2


### PR DESCRIPTION
relates to #455 