### PR TITLE
Rename test names to format FunctionNameFormYTest

### DIFF
--- a/test/unit_tests/cuda/unit_test_image_function_cuda.cpp
+++ b/test/unit_tests/cuda/unit_test_image_function_cuda.cpp
@@ -14,7 +14,7 @@ namespace image_function_cuda
 {
     using namespace Unit_Test;
 
-    bool AbsoluteDifference2ParametersTest()
+    bool AbsoluteDifferenceForm1Test()
     {
         for( uint32_t i = 0; i < runCount(); ++i ) {
             const std::vector < uint8_t > intensity = intensityArray( 2 );
@@ -30,7 +30,7 @@ namespace image_function_cuda
         return true;
     }
 
-    bool AbsoluteDifference3ParametersTest()
+    bool AbsoluteDifferenceForm2Test()
     {
         for( uint32_t i = 0; i < runCount(); ++i ) {
             const std::vector < uint8_t > intensity = intensityArray( 3 );
@@ -45,7 +45,7 @@ namespace image_function_cuda
         return true;
     }
 
-    bool BitwiseAnd2ParametersTest()
+    bool BitwiseAndForm1Test()
     {
         for( uint32_t i = 0; i < runCount(); ++i ) {
             const std::vector < uint8_t > intensity = intensityArray( 2 );
@@ -60,7 +60,7 @@ namespace image_function_cuda
         return true;
     }
 
-    bool BitwiseAnd3ParametersTest()
+    bool BitwiseAndForm2Test()
     {
         for( uint32_t i = 0; i < runCount(); ++i ) {
             const std::vector < uint8_t > intensity = intensityArray( 3 );
@@ -75,7 +75,7 @@ namespace image_function_cuda
         return true;
     }
 
-    bool BitwiseOr2ParametersTest()
+    bool BitwiseOrForm1Test()
     {
         for( uint32_t i = 0; i < runCount(); ++i ) {
             const std::vector < uint8_t > intensity = intensityArray( 2 );
@@ -90,7 +90,7 @@ namespace image_function_cuda
         return true;
     }
 
-    bool BitwiseOr3ParametersTest()
+    bool BitwiseOrForm2Test()
     {
         for( uint32_t i = 0; i < runCount(); ++i ) {
             const std::vector < uint8_t > intensity = intensityArray( 3 );
@@ -105,7 +105,7 @@ namespace image_function_cuda
         return true;
     }
 
-    bool BitwiseXor2ParametersTest()
+    bool BitwiseXorForm1Test()
     {
         for( uint32_t i = 0; i < runCount(); ++i ) {
             const std::vector < uint8_t > intensity = intensityArray( 2 );
@@ -120,7 +120,7 @@ namespace image_function_cuda
         return true;
     }
 
-    bool BitwiseXor3ParametersTest()
+    bool BitwiseXorForm2Test()
     {
         for( uint32_t i = 0; i < runCount(); ++i ) {
             const std::vector < uint8_t > intensity = intensityArray( 3 );
@@ -135,7 +135,7 @@ namespace image_function_cuda
         return true;
     }
 
-    bool ConvertToGrayScale1ParameterTest()
+    bool ConvertToGrayScaleForm1Test()
     {
         for( uint32_t i = 0; i < runCount(); ++i ) {
             const std::vector < uint8_t > intensity = intensityArray( 1 );
@@ -150,7 +150,7 @@ namespace image_function_cuda
         return true;
     }
 
-    bool ConvertToGrayScale2ParametersTest()
+    bool ConvertToGrayScaleForm2Test()
     {
         for( uint32_t i = 0; i < runCount(); ++i ) {
             const std::vector < uint8_t > intensity = intensityArray( 2 );
@@ -168,7 +168,7 @@ namespace image_function_cuda
         return true;
     }
 
-    bool ConvertToRgb1ParameterTest()
+    bool ConvertToRgbForm1Test()
     {
         for( uint32_t i = 0; i < runCount(); ++i ) {
             const std::vector < uint8_t > intensity = intensityArray( 1 );
@@ -183,7 +183,7 @@ namespace image_function_cuda
         return true;
     }
 
-    bool ConvertToRgb2ParametersTest()
+    bool ConvertToRgbForm2Test()
     {
         for( uint32_t i = 0; i < runCount(); ++i ) {
             const std::vector < uint8_t > intensity = intensityArray( 2 );
@@ -201,7 +201,7 @@ namespace image_function_cuda
         return true;
     }
 
-    bool GammaCorrection3ParametersTest()
+    bool GammaCorrectionForm1Test()
     {
         for( uint32_t i = 0; i < runCount(); ++i ) {
             const uint8_t intensity = intensityValue();
@@ -222,7 +222,7 @@ namespace image_function_cuda
         return true;
     }
 
-    bool GammaCorrection4ParametersTest()
+    bool GammaCorrectionForm2Test()
     {
         for( uint32_t i = 0; i < runCount(); ++i ) {
             const std::vector < uint8_t > intensity = intensityArray( 2 );
@@ -243,7 +243,7 @@ namespace image_function_cuda
         return true;
     }
 
-    bool Histogram1ParameterTest()
+    bool HistogramForm1Test()
     {
         for( uint32_t i = 0; i < runCount(); ++i ) {
             const uint8_t intensity = intensityValue();
@@ -259,7 +259,7 @@ namespace image_function_cuda
         return true;
     }
 
-    bool Histogram2ParametersTest()
+    bool HistogramForm2Test()
     {
         for( uint32_t i = 0; i < runCount(); ++i ) {
             const uint8_t intensity = intensityValue();
@@ -276,7 +276,7 @@ namespace image_function_cuda
         return true;
     }
 
-    bool Invert1ParameterTest()
+    bool InvertForm1Test()
     {
         for( uint32_t i = 0; i < runCount(); ++i ) {
             const uint8_t intensity = intensityValue();
@@ -291,7 +291,7 @@ namespace image_function_cuda
         return true;
     }
 
-    bool Invert2ParametersTest()
+    bool InvertForm2Test()
     {
         for( uint32_t i = 0; i < runCount(); ++i ) {
             const std::vector < uint8_t > intensity = intensityArray( 2 );
@@ -306,7 +306,7 @@ namespace image_function_cuda
         return true;
     }
 
-    bool LookupTable2ParametersTest()
+    bool LookupTableForm1Test()
     {
         for( uint32_t i = 0; i < runCount(); ++i ) {
             const std::vector < uint8_t > intensity = intensityArray( 2 );
@@ -331,7 +331,7 @@ namespace image_function_cuda
         return true;
     }
 
-    bool LookupTable3ParametersTest()
+    bool LookupTableForm2Test()
     {
         for( uint32_t i = 0; i < runCount(); ++i ) {
             const std::vector < uint8_t > intensity = intensityArray( 2 );
@@ -359,7 +359,7 @@ namespace image_function_cuda
         return true;
     }
 
-    bool Maximum2ParametersTest()
+    bool MaximumForm1Test()
     {
         for( uint32_t i = 0; i < runCount(); ++i ) {
             const std::vector < uint8_t > intensity = intensityArray( 2 );
@@ -375,7 +375,7 @@ namespace image_function_cuda
         return true;
     }
 
-    bool Maximum3ParametersTest()
+    bool MaximumForm2Test()
     {
         for( uint32_t i = 0; i < runCount(); ++i ) {
             const std::vector < uint8_t > intensity = intensityArray( 3 );
@@ -390,7 +390,7 @@ namespace image_function_cuda
         return true;
     }
 
-    bool Minimum2ParametersTest()
+    bool MinimumForm1Test()
     {
         for( uint32_t i = 0; i < runCount(); ++i ) {
             const std::vector < uint8_t > intensity = intensityArray( 2 );
@@ -406,7 +406,7 @@ namespace image_function_cuda
         return true;
     }
 
-    bool Minimum3ParametersTest()
+    bool MinimumForm2Test()
     {
         for( uint32_t i = 0; i < runCount(); ++i ) {
             const std::vector < uint8_t > intensity = intensityArray( 3 );
@@ -421,7 +421,7 @@ namespace image_function_cuda
         return true;
     }
 
-    bool Subtract2ParametersTest()
+    bool SubtractForm1Test()
     {
         for( uint32_t i = 0; i < runCount(); ++i ) {
             const std::vector < uint8_t > intensity = intensityArray( 2 );
@@ -437,7 +437,7 @@ namespace image_function_cuda
         return true;
     }
 
-    bool Subtract3ParametersTest()
+    bool SubtractForm2Test()
     {
         for( uint32_t i = 0; i < runCount(); ++i ) {
             const std::vector < uint8_t > intensity = intensityArray( 3 );
@@ -452,7 +452,7 @@ namespace image_function_cuda
         return true;
     }
 
-    bool Threshold2ParametersTest()
+    bool ThresholdForm1Test()
     {
         for( uint32_t i = 0; i < runCount(); ++i ) {
             const uint8_t intensity = intensityValue();
@@ -469,7 +469,7 @@ namespace image_function_cuda
         return true;
     }
 
-    bool Threshold3ParametersTest()
+    bool ThresholdForm2Test()
     {
         for( uint32_t i = 0; i < runCount(); ++i ) {
             const std::vector < uint8_t > intensity = intensityArray( 2 );
@@ -486,7 +486,7 @@ namespace image_function_cuda
         return true;
     }
 
-    bool ThresholdDouble3ParametersTest()
+    bool ThresholdDoubleForm1Test()
     {
         for( uint32_t i = 0; i < runCount(); ++i ) {
             const uint8_t intensity = intensityValue();
@@ -504,7 +504,7 @@ namespace image_function_cuda
         return true;
     }
 
-    bool ThresholdDouble4ParametersTest()
+    bool ThresholdDoubleForm2Test()
     {
         for( uint32_t i = 0; i < runCount(); ++i ) {
             const std::vector < uint8_t > intensity = intensityArray( 2 );
@@ -525,48 +525,48 @@ namespace image_function_cuda
 
 void addTests_Image_Function_Cuda( UnitTestFramework & framework )
 {
-    ADD_TEST( framework, image_function_cuda::AbsoluteDifference2ParametersTest );
-    ADD_TEST( framework, image_function_cuda::AbsoluteDifference3ParametersTest );
+    ADD_TEST( framework, image_function_cuda::AbsoluteDifferenceForm1Test );
+    ADD_TEST( framework, image_function_cuda::AbsoluteDifferenceForm2Test );
 
-    ADD_TEST( framework, image_function_cuda::BitwiseAnd2ParametersTest );
-    ADD_TEST( framework, image_function_cuda::BitwiseAnd3ParametersTest );
+    ADD_TEST( framework, image_function_cuda::BitwiseAndForm1Test );
+    ADD_TEST( framework, image_function_cuda::BitwiseAndForm2Test );
 
-    ADD_TEST( framework, image_function_cuda::BitwiseOr2ParametersTest );
-    ADD_TEST( framework, image_function_cuda::BitwiseOr3ParametersTest );
+    ADD_TEST( framework, image_function_cuda::BitwiseOrForm1Test );
+    ADD_TEST( framework, image_function_cuda::BitwiseOrForm2Test );
 
-    ADD_TEST( framework, image_function_cuda::BitwiseXor2ParametersTest );
-    ADD_TEST( framework, image_function_cuda::BitwiseXor3ParametersTest );
+    ADD_TEST( framework, image_function_cuda::BitwiseXorForm1Test );
+    ADD_TEST( framework, image_function_cuda::BitwiseXorForm2Test );
 
-    ADD_TEST( framework, image_function_cuda::ConvertToGrayScale1ParameterTest );
-    ADD_TEST( framework, image_function_cuda::ConvertToGrayScale2ParametersTest );
+    ADD_TEST( framework, image_function_cuda::ConvertToGrayScaleForm1Test );
+    ADD_TEST( framework, image_function_cuda::ConvertToGrayScaleForm2Test );
 
-    ADD_TEST( framework, image_function_cuda::ConvertToRgb1ParameterTest );
-    ADD_TEST( framework, image_function_cuda::ConvertToRgb2ParametersTest );
+    ADD_TEST( framework, image_function_cuda::ConvertToRgbForm1Test );
+    ADD_TEST( framework, image_function_cuda::ConvertToRgbForm2Test );
 
-    ADD_TEST( framework, image_function_cuda::GammaCorrection3ParametersTest );
-    ADD_TEST( framework, image_function_cuda::GammaCorrection4ParametersTest );
+    ADD_TEST( framework, image_function_cuda::GammaCorrectionForm1Test );
+    ADD_TEST( framework, image_function_cuda::GammaCorrectionForm2Test );
 
-    ADD_TEST( framework, image_function_cuda::Histogram1ParameterTest );
-    ADD_TEST( framework, image_function_cuda::Histogram2ParametersTest );
+    ADD_TEST( framework, image_function_cuda::HistogramForm1Test );
+    ADD_TEST( framework, image_function_cuda::HistogramForm2Test );
 
-    ADD_TEST( framework, image_function_cuda::Invert1ParameterTest );
-    ADD_TEST( framework, image_function_cuda::Invert2ParametersTest );
+    ADD_TEST( framework, image_function_cuda::InvertForm1Test );
+    ADD_TEST( framework, image_function_cuda::InvertForm2Test );
 
-    ADD_TEST( framework, image_function_cuda::LookupTable2ParametersTest );
-    ADD_TEST( framework, image_function_cuda::LookupTable3ParametersTest );
+    ADD_TEST( framework, image_function_cuda::LookupTableForm1Test );
+    ADD_TEST( framework, image_function_cuda::LookupTableForm2Test );
 
-    ADD_TEST( framework, image_function_cuda::Maximum2ParametersTest );
-    ADD_TEST( framework, image_function_cuda::Maximum3ParametersTest );
+    ADD_TEST( framework, image_function_cuda::MaximumForm1Test );
+    ADD_TEST( framework, image_function_cuda::MaximumForm2Test );
 
-    ADD_TEST( framework, image_function_cuda::Minimum2ParametersTest );
-    ADD_TEST( framework, image_function_cuda::Minimum3ParametersTest );
+    ADD_TEST( framework, image_function_cuda::MinimumForm1Test );
+    ADD_TEST( framework, image_function_cuda::MinimumForm2Test );
 
-    ADD_TEST( framework, image_function_cuda::Subtract2ParametersTest );
-    ADD_TEST( framework, image_function_cuda::Subtract3ParametersTest );
+    ADD_TEST( framework, image_function_cuda::SubtractForm1Test );
+    ADD_TEST( framework, image_function_cuda::SubtractForm2Test );
 
-    ADD_TEST( framework, image_function_cuda::Threshold2ParametersTest );
-    ADD_TEST( framework, image_function_cuda::Threshold3ParametersTest );
+    ADD_TEST( framework, image_function_cuda::ThresholdForm1Test );
+    ADD_TEST( framework, image_function_cuda::ThresholdForm2Test );
 
-    ADD_TEST( framework, image_function_cuda::ThresholdDouble3ParametersTest );
-    ADD_TEST( framework, image_function_cuda::ThresholdDouble4ParametersTest );
+    ADD_TEST( framework, image_function_cuda::ThresholdDoubleForm1Test );
+    ADD_TEST( framework, image_function_cuda::ThresholdDoubleForm2Test );
 }


### PR DESCRIPTION
### Changes:

- Rename the format of Test Cases to `{FunctionNameFormYTest}`

Reference task: https://github.com/ihhub/penguinV/issues/540