### PR TITLE
Added support in LookupTable() for CUDA to support color images (#546)

### DIFF
--- a/src/cuda/image_function_cuda.cu
+++ b/src/cuda/image_function_cuda.cu
@@ -912,12 +912,12 @@ namespace Image_Function_Cuda
             throw imageException( "Lookup table size is not equal to 256" );
 
         const uint8_t colorCount = CommonColorCount( in, out );
-        width = width * colorCount;  //this change is not reflected anywhere else
+        width = width * colorCount;
 
         const uint32_t rowSizeIn  = in.rowSize();
         const uint32_t rowSizeOut = out.rowSize();
 
-        const uint8_t * inY  = in.data()  + startYIn  * rowSizeIn  + startXIn * colorCount;
+        const uint8_t * inY  = in.data()  + startYIn  * rowSizeIn  + startXIn  * colorCount;
         uint8_t       * outY = out.data() + startYOut * rowSizeOut + startXOut * colorCount;
 
         multiCuda::Array< uint8_t > tableCuda( table );

--- a/src/cuda/image_function_cuda.cu
+++ b/src/cuda/image_function_cuda.cu
@@ -907,16 +907,18 @@ namespace Image_Function_Cuda
                       uint32_t width, uint32_t height, const std::vector < uint8_t > & table )
     {
         Image_Function::ParameterValidation( in, startXIn, startYIn, out, startXOut, startYOut, width, height );
-        Image_Function::VerifyGrayScaleImage( in, out );
 
         if ( table.size() != 256u )
             throw imageException( "Lookup table size is not equal to 256" );
 
+        const uint8_t colorCount = CommonColorCount( in, out );
+        width = width * colorCount;  //this change is not reflected anywhere else
+
         const uint32_t rowSizeIn  = in.rowSize();
         const uint32_t rowSizeOut = out.rowSize();
 
-        const uint8_t * inY  = in.data()  + startYIn  * rowSizeIn  + startXIn;
-        uint8_t       * outY = out.data() + startYOut * rowSizeOut + startXOut;
+        const uint8_t * inY  = in.data()  + startYIn  * rowSizeIn  + startXIn * colorCount;
+        uint8_t       * outY = out.data() + startYOut * rowSizeOut + startXOut * colorCount;
 
         multiCuda::Array< uint8_t > tableCuda( table );
 

--- a/src/cuda/image_function_cuda.cu
+++ b/src/cuda/image_function_cuda.cu
@@ -911,7 +911,7 @@ namespace Image_Function_Cuda
         if ( table.size() != 256u )
             throw imageException( "Lookup table size is not equal to 256" );
 
-        const uint8_t colorCount = CommonColorCount( in, out );
+        const uint8_t colorCount = Image_Function::CommonColorCount( in, out );
         width = width * colorCount;
 
         const uint32_t rowSizeIn  = in.rowSize();


### PR DESCRIPTION
Fixes issue ( #546 )
The variable width is changed according to color, but is not used anywhere else. Isn't this a concern?
The variable width could be passed by reference instead.