### PR TITLE
BitwiseXor, ConvertTo16Bit, ConvertTo8Bit implementation for AVX512

### DIFF
--- a/src/image_function_simd.cpp
+++ b/src/image_function_simd.cpp
@@ -189,24 +189,24 @@ namespace avx512
     void BitwiseXor( uint32_t rowSizeIn1, uint32_t rowSizeIn2, uint32_t rowSizeOut, const uint8_t * in1Y, const uint8_t * in2Y,
                      uint8_t * outY, const uint8_t * outYEnd, uint32_t simdWidth, uint32_t totalSimdWidth, uint32_t nonSimdWidth )
     {
-        for( ; outY != outYEnd; outY += rowSizeOut, in1Y += rowSizeIn1, in2Y += rowSizeIn2 ) {
+        for ( ; outY != outYEnd; outY += rowSizeOut, in1Y += rowSizeIn1, in2Y += rowSizeIn2 ) {
             const simd * src1 = reinterpret_cast <const simd*> (in1Y);
             const simd * src2 = reinterpret_cast <const simd*> (in2Y);
             simd       * dst  = reinterpret_cast <simd*> (outY);
 
             const simd * src1End = src1 + simdWidth;
 
-            for( ; src1 != src1End; ++src1, ++src2, ++dst )
+            for ( ; src1 != src1End; ++src1, ++src2, ++dst )
                 _mm512_storeu_si512( dst, _mm512_xor_si512( _mm512_loadu_si512( src1 ), _mm512_loadu_si512( src2 ) ) );
 
-            if( nonSimdWidth > 0 ) {
+            if ( nonSimdWidth > 0 ) {
                 const uint8_t * in1X = in1Y + totalSimdWidth;
                 const uint8_t * in2X = in2Y + totalSimdWidth;
                 uint8_t       * outX = outY + totalSimdWidth;
 
                 const uint8_t * outXEnd = outX + nonSimdWidth;
 
-                for( ; outX != outXEnd; ++outX, ++in1X, ++in2X )
+                for ( ; outX != outXEnd; ++outX, ++in1X, ++in2X )
                     (*outX) = (*in1X) ^ (*in2X);
             }
         }

--- a/src/image_function_simd.cpp
+++ b/src/image_function_simd.cpp
@@ -185,6 +185,87 @@ namespace avx512
             }
         }
     }
+
+    void BitwiseXor( uint32_t rowSizeIn1, uint32_t rowSizeIn2, uint32_t rowSizeOut, const uint8_t * in1Y, const uint8_t * in2Y,
+                     uint8_t * outY, const uint8_t * outYEnd, uint32_t simdWidth, uint32_t totalSimdWidth, uint32_t nonSimdWidth )
+    {
+        for( ; outY != outYEnd; outY += rowSizeOut, in1Y += rowSizeIn1, in2Y += rowSizeIn2 ) {
+            const simd * src1 = reinterpret_cast <const simd*> (in1Y);
+            const simd * src2 = reinterpret_cast <const simd*> (in2Y);
+            simd       * dst  = reinterpret_cast <simd*> (outY);
+
+            const simd * src1End = src1 + simdWidth;
+
+            for( ; src1 != src1End; ++src1, ++src2, ++dst )
+                _mm512_storeu_si512( dst, _mm512_xor_si512( _mm512_loadu_si512( src1 ), _mm512_loadu_si512( src2 ) ) );
+
+            if( nonSimdWidth > 0 ) {
+                const uint8_t * in1X = in1Y + totalSimdWidth;
+                const uint8_t * in2X = in2Y + totalSimdWidth;
+                uint8_t       * outX = outY + totalSimdWidth;
+
+                const uint8_t * outXEnd = outX + nonSimdWidth;
+
+                for( ; outX != outXEnd; ++outX, ++in1X, ++in2X )
+                    (*outX) = (*in1X) ^ (*in2X);
+            }
+        }
+    }
+
+    void ConvertTo16Bit( uint16_t * outY, const uint16_t * outYEnd, const uint8_t * inY, uint32_t rowSizeOut, uint32_t rowSizeIn,
+                         uint32_t simdWidth, uint32_t totalSimdWidth, uint32_t nonSimdWidth )
+    {
+        const simd zero = _mm512_setzero_si512();
+        for ( ; outY != outYEnd; outY += rowSizeOut, inY += rowSizeIn ) {
+            const simd  * src    = reinterpret_cast <const simd*> (inY);
+            simd        * dst    = reinterpret_cast <simd*> (outY);
+            const simd  * srcEnd = src + simdWidth;
+
+            for ( ; src != srcEnd; ++src ) {
+                const simd srcData = _mm512_loadu_si512( src );
+
+                _mm512_storeu_si512( dst++, _mm512_unpacklo_epi8( zero, srcData ) );
+                _mm512_storeu_si512( dst++, _mm512_unpacklo_epi8( zero, srcData ) );
+            }
+            
+            if ( nonSimdWidth > 0 ) {
+                const uint8_t  * inX  = inY + totalSimdWidth;
+                uint16_t       * outX = outY + totalSimdWidth;
+                const uint16_t * outXEnd = outX + nonSimdWidth;
+
+                for ( ; outX != outXEnd; ++outX, ++inX )
+                    *outX = static_cast<uint16_t>( (*inX) << 8 );
+            }
+        }
+    }
+
+    void ConvertTo8Bit( uint8_t * outY, const uint8_t * outYEnd, const uint16_t * inY, uint32_t rowSizeOut, uint32_t rowSizeIn,
+                        uint32_t simdWidth, uint32_t totalSimdWidth, uint32_t nonSimdWidth  )
+    {
+        for ( ; outY != outYEnd; outY += rowSizeOut, inY += rowSizeIn ) {
+            const simd  * src    = reinterpret_cast <const simd*> (inY);
+            simd        * dst    = reinterpret_cast <simd*> (outY);
+            const simd  * dstEnd = dst + simdWidth;
+
+            for ( ; dst != dstEnd; ++dst ) {
+                const simd srcData1 = _mm512_loadu_si512( src );
+                ++src;
+                const simd srcData2 = _mm512_loadu_si512( src );
+                ++src;
+
+                _mm512_storeu_si512(dst, _mm512_packus_epi16(_mm512_srli_epi16 ( srcData1, 8 ), _mm512_srli_epi16 ( srcData2, 8)));
+            }
+
+            if ( nonSimdWidth > 0 ) {
+                const uint16_t * inX  = inY + totalSimdWidth;
+                uint8_t        * outX = outY + totalSimdWidth;
+                const uint8_t  * outXEnd = outX + nonSimdWidth;
+
+                for ( ; outX != outXEnd; ++outX, ++inX )
+                    *outX = static_cast<uint8_t>( (*inX) >> 8 );
+            }
+        }
+    }
 #endif
 }
 

--- a/src/image_function_simd.cpp
+++ b/src/image_function_simd.cpp
@@ -186,13 +186,13 @@ namespace avx512
         }
     }
 
-    void BitwiseXor( uint32_t rowSizeIn1, uint32_t rowSizeIn2, uint32_t rowSizeOut, const uint8_t * in1Y, const uint8_t * in2Y,
-                     uint8_t * outY, const uint8_t * outYEnd, uint32_t simdWidth, uint32_t totalSimdWidth, uint32_t nonSimdWidth )
+    void BitwiseXor( uint32_t rowSizeIn1, uint32_t rowSizeIn2, uint32_t rowSizeOut, const uint8_t * in1Y, const uint8_t * in2Y, uint8_t * outY, const uint8_t * outYEnd,
+                     uint32_t simdWidth, uint32_t totalSimdWidth, uint32_t nonSimdWidth )
     {
         for ( ; outY != outYEnd; outY += rowSizeOut, in1Y += rowSizeIn1, in2Y += rowSizeIn2 ) {
-            const simd * src1 = reinterpret_cast <const simd*> (in1Y);
-            const simd * src2 = reinterpret_cast <const simd*> (in2Y);
-            simd       * dst  = reinterpret_cast <simd*> (outY);
+            const simd * src1 = reinterpret_cast<const simd*>(in1Y);
+            const simd * src2 = reinterpret_cast<const simd*>(in2Y);
+            simd       * dst  = reinterpret_cast<simd*>(outY);
 
             const simd * src1End = src1 + simdWidth;
 
@@ -217,8 +217,8 @@ namespace avx512
     {
         const simd zero = _mm512_setzero_si512();
         for ( ; outY != outYEnd; outY += rowSizeOut, inY += rowSizeIn ) {
-            const simd  * src    = reinterpret_cast <const simd*> (inY);
-            simd        * dst    = reinterpret_cast <simd*> (outY);
+            const simd  * src    = reinterpret_cast<const simd*>(inY);
+            simd        * dst    = reinterpret_cast<simd*>(outY);
             const simd  * srcEnd = src + simdWidth;
 
             for ( ; src != srcEnd; ++src ) {
@@ -243,8 +243,8 @@ namespace avx512
                         uint32_t simdWidth, uint32_t totalSimdWidth, uint32_t nonSimdWidth  )
     {
         for ( ; outY != outYEnd; outY += rowSizeOut, inY += rowSizeIn ) {
-            const simd  * src    = reinterpret_cast <const simd*> (inY);
-            simd        * dst    = reinterpret_cast <simd*> (outY);
+            const simd  * src    = reinterpret_cast<const simd*>(inY);
+            simd        * dst    = reinterpret_cast<simd*>(outY);
             const simd  * dstEnd = dst + simdWidth;
 
             for ( ; dst != dstEnd; ++dst ) {

--- a/test/performance_tests/performance_test_image_function.cpp
+++ b/test/performance_tests/performance_test_image_function.cpp
@@ -363,6 +363,7 @@ namespace image_function_avx512
     SET_FUNCTION( Accumulate         )
     SET_FUNCTION( BitwiseAnd         )
     SET_FUNCTION( BitwiseOr          )
+    SET_FUNCTION( BitwiseXor         )
 }
 #endif
 

--- a/test/unit_tests/unit_test_image_function.cpp
+++ b/test/unit_tests/unit_test_image_function.cpp
@@ -2581,6 +2581,9 @@ namespace avx512
     SET_FUNCTION_2_FORMS( Accumulate )
     SET_FUNCTION_4_FORMS( BitwiseAnd )
     SET_FUNCTION_4_FORMS( BitwiseOr )
+    SET_FUNCTION_4_FORMS( BitwiseXor )
+    SET_FUNCTION_4_FORMS( ConvertTo16Bit )
+    SET_FUNCTION_4_FORMS( ConvertTo8Bit )
 }
 #endif
 


### PR DESCRIPTION
PR for #86 

I added yet again three new function for AVX512 support.

The performance_tests and unit_tests compile with march=skylake-avx512