### PR TITLE
Build time reduction for all builds on servers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
         - cd test/unit_tests
       script:
         - make
-        - ./unit_tests 100
+        - ./unit_tests
         - cd ../performance_tests
         - make
         - cd ../../examples

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -53,7 +53,6 @@ before_build:
   - cmd: if "%configuration%"=="Release" call script\appveyor\cuda_install.cmd
 
 build_script:
-  - set PENGUINV_UNIT_TEST_RUN_COUNT=500
   - cmd: cd C:\projects\penguinv
   - cmd: md build
   - cmd: cd build

--- a/test/test_helper.cpp
+++ b/test/test_helper.cpp
@@ -38,7 +38,7 @@ namespace
         }
     }
 
-    uint32_t testRunCount = 100;  // some magic number for loop. Higher value = higher chance to verify all possible situations
+    uint32_t testRunCount = 100; // some magic number for loop. Higher value = higher chance to verify all possible situations
 }
 
 namespace Test_Helper

--- a/test/test_helper.cpp
+++ b/test/test_helper.cpp
@@ -38,7 +38,7 @@ namespace
         }
     }
 
-    uint32_t testRunCount = 1001;  // some magic number for loop. Higher value = higher chance to verify all possible situations
+    uint32_t testRunCount = 100;  // some magic number for loop. Higher value = higher chance to verify all possible situations
 }
 
 namespace Test_Helper

--- a/test/unit_tests/unit_tests.cpp
+++ b/test/unit_tests/unit_tests.cpp
@@ -10,7 +10,7 @@
 
 int main( int argc, char * argv[] )
 {
-    Unit_Test::setRunCount( argc, argv, 1001 );
+    Unit_Test::setRunCount( argc, argv, 100 );
 
     cpu_Memory::MemoryAllocator::instance().reserve( 32 * 1024 * 1024 ); // reserve preallocated memory
 


### PR DESCRIPTION
We face a huge problem with building times for our project which recently became a disaster. The plan is to reduce unit test run time for all builds but have a daily build with heavy load on unit tests.