### PR TITLE
Set unit test count to 1000 for cron job only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -97,6 +97,9 @@ before_script:
 script:
   - |
     # Build and run tests
+    if [[ "$TRAVIS_EVENT_TYPE" == "cron" ]]; then
+      export PENGUINV_UNIT_TEST_RUN_COUNT=1000
+    fi
     set -e
     cmake --build .
     set +e


### PR DESCRIPTION
From now we run all unit tests with count of 100 while we have daily job which we want to run with count 1000