### PR TITLE
Add Invert, Maximum, Minimum functions for AVX512

### DIFF
--- a/src/image_function_simd.cpp
+++ b/src/image_function_simd.cpp
@@ -2532,7 +2532,7 @@ if ( simdType == neon_function ) { \
         const uint32_t totalSimdWidth = simdWidth * simdSize;
         const uint32_t nonSimdWidth = width - totalSimdWidth;
 
-        AVX512BW_CODE( avx::BitwiseOr( rowSizeIn1, rowSizeIn2, rowSizeOut, in1Y, in2Y, outY, outYEnd, simdWidth, totalSimdWidth, nonSimdWidth ); )
+        AVX512BW_CODE( avx512::BitwiseOr( rowSizeIn1, rowSizeIn2, rowSizeOut, in1Y, in2Y, outY, outYEnd, simdWidth, totalSimdWidth, nonSimdWidth ); )
         AVX_CODE( avx::BitwiseOr( rowSizeIn1, rowSizeIn2, rowSizeOut, in1Y, in2Y, outY, outYEnd, simdWidth, totalSimdWidth, nonSimdWidth ); )
         SSE_CODE( sse::BitwiseOr( rowSizeIn1, rowSizeIn2, rowSizeOut, in1Y, in2Y, outY, outYEnd, simdWidth, totalSimdWidth, nonSimdWidth ); )
         NEON_CODE( neon::BitwiseOr( rowSizeIn1, rowSizeIn2, rowSizeOut, in1Y, in2Y, outY, outYEnd, simdWidth, totalSimdWidth, nonSimdWidth ); )

--- a/src/image_function_simd.cpp
+++ b/src/image_function_simd.cpp
@@ -2570,6 +2570,7 @@ if ( simdType == neon_function ) { \
         const uint32_t totalSimdWidth = simdWidth * simdSize;
         const uint32_t nonSimdWidth = width - totalSimdWidth;
 
+        AVX512BW_CODE( avx512::BitwiseXor( rowSizeIn1, rowSizeIn2, rowSizeOut, in1Y, in2Y, outY, outYEnd, simdWidth, totalSimdWidth, nonSimdWidth ); )
         AVX_CODE( avx::BitwiseXor( rowSizeIn1, rowSizeIn2, rowSizeOut, in1Y, in2Y, outY, outYEnd, simdWidth, totalSimdWidth, nonSimdWidth ); )
         SSE_CODE( sse::BitwiseXor( rowSizeIn1, rowSizeIn2, rowSizeOut, in1Y, in2Y, outY, outYEnd, simdWidth, totalSimdWidth, nonSimdWidth ); )
         NEON_CODE( neon::BitwiseXor( rowSizeIn1, rowSizeIn2, rowSizeOut, in1Y, in2Y, outY, outYEnd, simdWidth, totalSimdWidth, nonSimdWidth ); )
@@ -2606,6 +2607,7 @@ if ( simdType == neon_function ) { \
         const uint32_t totalSimdWidth = simdWidth * simdSize;
         const uint32_t nonSimdWidth = width - totalSimdWidth;
 
+        AVX512BW_CODE( avx512::ConvertTo16Bit( outY, outYEnd, inY, rowSizeOut, rowSizeIn, simdWidth, totalSimdWidth, nonSimdWidth ); )
         AVX_CODE( avx::ConvertTo16Bit( outY, outYEnd, inY, rowSizeOut, rowSizeIn, simdWidth, totalSimdWidth, nonSimdWidth ); )
         SSE_CODE( sse::ConvertTo16Bit( outY, outYEnd, inY, rowSizeOut, rowSizeIn, simdWidth, totalSimdWidth, nonSimdWidth ); )
         NEON_CODE( neon::ConvertTo16Bit( outY, outYEnd, inY, rowSizeOut, rowSizeIn, simdWidth, totalSimdWidth, nonSimdWidth ); )
@@ -2642,6 +2644,7 @@ if ( simdType == neon_function ) { \
         const uint32_t totalSimdWidth = simdWidth * simdSize;
         const uint32_t nonSimdWidth = width - totalSimdWidth;
 
+        AVX512BW_CODE( avx512::ConvertTo8Bit( outY, outYEnd, inY, rowSizeOut, rowSizeIn, simdWidth, totalSimdWidth, nonSimdWidth ); )
         AVX_CODE( avx::ConvertTo8Bit( outY, outYEnd, inY, rowSizeOut, rowSizeIn, simdWidth, totalSimdWidth, nonSimdWidth ); )
         SSE_CODE( sse::ConvertTo8Bit( outY, outYEnd, inY, rowSizeOut, rowSizeIn, simdWidth, totalSimdWidth, nonSimdWidth ); )
         NEON_CODE( neon::ConvertTo8Bit( outY, outYEnd, inY, rowSizeOut, rowSizeIn, simdWidth, totalSimdWidth, nonSimdWidth ); )

--- a/src/image_function_simd.cpp
+++ b/src/image_function_simd.cpp
@@ -281,22 +281,22 @@ namespace avx512
             maskValue, maskValue, maskValue, maskValue, maskValue, maskValue, maskValue, maskValue,
             maskValue, maskValue, maskValue, maskValue, maskValue, maskValue, maskValue, maskValue );
 
-        for( ; outY != outYEnd; outY += rowSizeOut, inY += rowSizeIn ) {
-            const simd * src1 = reinterpret_cast <const simd*> (inY);
-            simd       * dst  = reinterpret_cast <simd*> (outY);
+        for ( ; outY != outYEnd; outY += rowSizeOut, inY += rowSizeIn ) {
+            const simd * src1 = reinterpret_cast<const simd*>( inY );
+            simd       * dst  = reinterpret_cast<simd*>( outY );
 
             const simd * src1End = src1 + simdWidth;
 
-            for( ; src1 != src1End; ++src1, ++dst )
+            for ( ; src1 != src1End; ++src1, ++dst )
                 _mm512_storeu_si512( dst, _mm512_andnot_si512( _mm512_loadu_si512( src1 ), mask ) );
 
-            if( nonSimdWidth > 0 ) {
+            if ( nonSimdWidth > 0 ) {
                 const uint8_t * inX  = inY  + totalSimdWidth;
                 uint8_t       * outX = outY + totalSimdWidth;
 
                 const uint8_t * outXEnd = outX + nonSimdWidth;
 
-                for( ; outX != outXEnd; ++outX, ++inX )
+                for ( ; outX != outXEnd; ++outX, ++inX )
                     (*outX) = static_cast<uint8_t>( ~(*inX) );
             }
         }
@@ -305,25 +305,25 @@ namespace avx512
     void Maximum( uint32_t rowSizeIn1, uint32_t rowSizeIn2, uint32_t rowSizeOut, const uint8_t * in1Y, const uint8_t * in2Y,
                   uint8_t * outY, const uint8_t * outYEnd, uint32_t simdWidth, uint32_t totalSimdWidth, uint32_t nonSimdWidth )
     {
-        for( ; outY != outYEnd; outY += rowSizeOut, in1Y += rowSizeIn1, in2Y += rowSizeIn2 ) {
-            const simd * src1 = reinterpret_cast <const simd*> (in1Y);
-            const simd * src2 = reinterpret_cast <const simd*> (in2Y);
-            simd       * dst  = reinterpret_cast <simd*> (outY);
+        for ( ; outY != outYEnd; outY += rowSizeOut, in1Y += rowSizeIn1, in2Y += rowSizeIn2 ) {
+            const simd * src1 = reinterpret_cast<const simd*>( in1Y );
+            const simd * src2 = reinterpret_cast<const simd*>( in2Y );
+            simd       * dst  = reinterpret_cast<simd*>( outY );
 
             const simd * src1End = src1 + simdWidth;
 
-            for( ; src1 != src1End; ++src1, ++src2, ++dst )
+            for ( ; src1 != src1End; ++src1, ++src2, ++dst )
                 _mm512_storeu_si512( dst, _mm512_max_epu8( _mm512_loadu_si512( src1 ), _mm512_loadu_si512( src2 ) ) );
 
-            if( nonSimdWidth > 0 ) {
+            if ( nonSimdWidth > 0 ) {
                 const uint8_t * in1X = in1Y + totalSimdWidth;
                 const uint8_t * in2X = in2Y + totalSimdWidth;
                 uint8_t       * outX = outY + totalSimdWidth;
 
                 const uint8_t * outXEnd = outX + nonSimdWidth;
 
-                for( ; outX != outXEnd; ++outX, ++in1X, ++in2X ) {
-                    if( (*in2X) < (*in1X) )
+                for ( ; outX != outXEnd; ++outX, ++in1X, ++in2X ) {
+                    if ( (*in2X) < (*in1X) )
                         (*outX) = (*in1X);
                     else
                         (*outX) = (*in2X);
@@ -335,25 +335,25 @@ namespace avx512
     void Minimum( uint32_t rowSizeIn1, uint32_t rowSizeIn2, uint32_t rowSizeOut, const uint8_t * in1Y, const uint8_t * in2Y,
                   uint8_t * outY, const uint8_t * outYEnd, uint32_t simdWidth, uint32_t totalSimdWidth, uint32_t nonSimdWidth )
     {
-        for( ; outY != outYEnd; outY += rowSizeOut, in1Y += rowSizeIn1, in2Y += rowSizeIn2 ) {
-            const simd * src1 = reinterpret_cast <const simd*> (in1Y);
-            const simd * src2 = reinterpret_cast <const simd*> (in2Y);
-            simd       * dst  = reinterpret_cast <simd*> (outY);
+        for ( ; outY != outYEnd; outY += rowSizeOut, in1Y += rowSizeIn1, in2Y += rowSizeIn2 ) {
+            const simd * src1 = reinterpret_cast<const simd*>( in1Y );
+            const simd * src2 = reinterpret_cast<const simd*>( in2Y );
+            simd       * dst  = reinterpret_cast<simd*>( outY );
 
             const simd * src1End = src1 + simdWidth;
 
-            for( ; src1 != src1End; ++src1, ++src2, ++dst )
+            for ( ; src1 != src1End; ++src1, ++src2, ++dst )
                 _mm512_storeu_si512( dst, _mm512_min_epu8( _mm512_loadu_si512( src1 ), _mm512_loadu_si512( src2 ) ) );
 
-            if( nonSimdWidth > 0 ) {
+            if ( nonSimdWidth > 0 ) {
                 const uint8_t * in1X = in1Y + totalSimdWidth;
                 const uint8_t * in2X = in2Y + totalSimdWidth;
                 uint8_t       * outX = outY + totalSimdWidth;
 
                 const uint8_t * outXEnd = outX + nonSimdWidth;
 
-                for( ; outX != outXEnd; ++outX, ++in1X, ++in2X ) {
-                    if( (*in2X) > (*in1X) )
+                for ( ; outX != outXEnd; ++outX, ++in1X, ++in2X ) {
+                    if ( (*in2X) > (*in1X) )
                         (*outX) = (*in1X);
                     else
                         (*outX) = (*in2X);

--- a/test/performance_tests/performance_test_image_function.cpp
+++ b/test/performance_tests/performance_test_image_function.cpp
@@ -364,6 +364,8 @@ namespace image_function_avx512
     SET_FUNCTION( BitwiseAnd         )
     SET_FUNCTION( BitwiseOr          )
     SET_FUNCTION( BitwiseXor         )
+    SET_FUNCTION( Invert             )
+    SET_FUNCTION( Maximum            )
 }
 #endif
 

--- a/test/unit_tests/unit_test_image_function.cpp
+++ b/test/unit_tests/unit_test_image_function.cpp
@@ -2584,6 +2584,9 @@ namespace avx512
     SET_FUNCTION_4_FORMS( BitwiseXor )
     SET_FUNCTION_4_FORMS( ConvertTo16Bit )
     SET_FUNCTION_4_FORMS( ConvertTo8Bit )
+    SET_FUNCTION_4_FORMS( Invert )
+    SET_FUNCTION_4_FORMS( Maximum )
+    SET_FUNCTION_4_FORMS( Minimum )
 }
 #endif
 


### PR DESCRIPTION
PR for #86

I added yet again three new function for AVX512 support.
The performance_tests and unit_tests compile with march=skylake-avx512.

I can't test if the unit and performance tests work because I don't have a AVX512 processor in my possession.

I also fixes some missing code of my previous commit.