### PR TITLE
add more condition to enable avx512 compilation

### DIFF
--- a/src/penguinv/cpu_identification.h
+++ b/src/penguinv/cpu_identification.h
@@ -37,7 +37,15 @@
         #endif
 
         #ifdef __AVX512BW__
-            #define PENGUINV_AVX512BW_SET
+            #ifdef __AVX512CD__
+                #ifdef __AVX512DQ__
+                    #ifdef __AVX512F__
+                        #ifdef __AVX512VL__
+                            #define PENGUINV_AVX512BW_SET
+                        #endif
+                    #endif
+                #endif
+            #endif
         #endif
     #endif
 

--- a/src/penguinv/cpu_identification.h
+++ b/src/penguinv/cpu_identification.h
@@ -36,16 +36,11 @@
             #define PENGUINV_AVX_SET
         #endif
 
-        #ifdef __AVX512BW__
-            #ifdef __AVX512CD__
-                #ifdef __AVX512DQ__
-                    #ifdef __AVX512F__
-                        #ifdef __AVX512VL__
-                            #define PENGUINV_AVX512BW_SET
-                        #endif
-                    #endif
-                #endif
-            #endif
+        #if defined(__AVX512BW__) && defined(__AVX512CD__) && defined(__AVX512DQ__) && defined(__AVX512F__) && \
+            defined(__AVX512VL__)
+
+            #define PENGUINV_AVX512BW_SET
+            
         #endif
     #endif
 

--- a/src/penguinv/cpu_identification.h
+++ b/src/penguinv/cpu_identification.h
@@ -36,11 +36,8 @@
             #define PENGUINV_AVX_SET
         #endif
 
-        #if defined(__AVX512BW__) && defined(__AVX512CD__) && defined(__AVX512DQ__) && defined(__AVX512F__) && \
-            defined(__AVX512VL__)
-
+        #if defined(__AVX512BW__) && defined(__AVX512CD__) && defined(__AVX512DQ__) && defined(__AVX512F__) && defined(__AVX512VL__)
             #define PENGUINV_AVX512BW_SET
-            
         #endif
     #endif
 


### PR DESCRIPTION
here's a hotfix for #582.

It should solve the compilation problem only. We still need to add the flag identification for all the other avx512 module in cpu_id_unix.h and cpu_id_windows.h. Maybe also renaming PENGUINV_AVX512BW_SET define for PENGUINV_AVX512_SKYLAKE_SET since it's more accurate