### PR TITLE
AVX-512 implementation for ProjectionProfile, Sum and Subtract

### DIFF
--- a/src/image_function_simd.cpp
+++ b/src/image_function_simd.cpp
@@ -446,10 +446,11 @@ namespace avx512
                         (*out) += (*imageX);
                 }
 
-                uint32_t output[8] = { 0 };
+                uint32_t output[16] = { 0 };
                 _mm512_storeu_si512( reinterpret_cast <simd*>(output), simdSum );
 
-                (*out) += output[0] + output[1] + output[2] + output[3] + output[4] + output[5] + output[6] + output[7];
+                (*out) += output[0] + output[1] + output[2] + output[3] + output[4] + output[5] + output[6] + output[7] +
+                          output[8] + output[9] + output[10] + output[11] + output[12] + output[13] + output[14] + output[15];
             }
         }
     }
@@ -511,11 +512,12 @@ namespace avx512
             }
         }
 
-        uint32_t output[8] = { 0 };
+        uint32_t output[16] = { 0 };
 
         _mm512_storeu_si512( reinterpret_cast <simd*>(output), simdSum );
 
-        return sum + output[0] + output[1] + output[2] + output[3] + output[4] + output[5] + output[6] + output[7];
+        return sum + output[0] + output[1] + output[2] + output[3] + output[4] + output[5] + output[6] + output[7] +
+                     output[8] + output[9] + output[10] + output[11] + output[12] + output[13] + output[14] + output[15];
     }
 #endif
 }

--- a/src/image_function_simd.cpp
+++ b/src/image_function_simd.cpp
@@ -378,10 +378,10 @@ namespace avx512
                 simd simdSum_3 = _mm512_setzero_si512();
                 simd simdSum_4 = _mm512_setzero_si512();
 
-                simd * dst = reinterpret_cast <simd*>(out);
+                simd * dst = reinterpret_cast<simd *>( out );
 
                 for ( ; imageSimdY != imageSimdYEnd; imageSimdY += rowSize ) {
-                    const simd * src = reinterpret_cast <const simd*>(imageSimdY);
+                    const simd * src = reinterpret_cast<const simd *>( imageSimdY );
 
                     const simd data = _mm512_loadu_si512( src );
 
@@ -408,7 +408,7 @@ namespace avx512
             }
 
             if ( nonSimdWidth > 0 ) {
-                const uint8_t* imageXEnd = imageStart + nonSimdWidth;
+                const uint8_t * imageXEnd = imageStart + nonSimdWidth;
 
                 for ( ; imageStart != imageXEnd; ++imageStart, ++out ) {
                     const uint8_t * imageY    = imageStart;
@@ -447,7 +447,7 @@ namespace avx512
                 }
 
                 uint32_t output[16] = { 0 };
-                _mm512_storeu_si512( reinterpret_cast <simd*>(output), simdSum );
+                _mm512_storeu_si512( reinterpret_cast<simd *>( output ), simdSum );
 
                 (*out) += output[0] + output[1] + output[2] + output[3] + output[4] + output[5] + output[6] + output[7] +
                           output[8] + output[9] + output[10] + output[11] + output[12] + output[13] + output[14] + output[15];
@@ -486,7 +486,7 @@ namespace avx512
     {
         uint32_t sum = 0;
         simd simdSum = _mm512_setzero_si512();
-        simd zero    = _mm512_setzero_si512();
+        const simd zero = _mm512_setzero_si512();
 
         for ( ; imageY != imageYEnd; imageY += rowSize ) {
             const simd * src    = reinterpret_cast <const simd*> (imageY);

--- a/src/image_function_simd.cpp
+++ b/src/image_function_simd.cpp
@@ -367,10 +367,10 @@ namespace avx512
     {
         const simd zero = _mm512_setzero_si512();
 
-        if( horizontal ) {
+        if ( horizontal ) {
             const uint8_t * imageSimdXEnd = imageStart + totalSimdWidth;
 
-            for( ; imageStart != imageSimdXEnd; imageStart += simdSize, out += simdSize ) {
+            for ( ; imageStart != imageSimdXEnd; imageStart += simdSize, out += simdSize ) {
                 const uint8_t * imageSimdY = imageStart;
                 const uint8_t * imageSimdYEnd = imageSimdY + height * rowSize;
                 simd simdSum_1 = _mm512_setzero_si512();
@@ -378,15 +378,15 @@ namespace avx512
                 simd simdSum_3 = _mm512_setzero_si512();
                 simd simdSum_4 = _mm512_setzero_si512();
 
-                simd * dst = reinterpret_cast <simd*> (out);
+                simd * dst = reinterpret_cast <simd*>(out);
 
-                for( ; imageSimdY != imageSimdYEnd; imageSimdY += rowSize) {
-                    const simd * src    = reinterpret_cast <const simd*> (imageSimdY);
+                for ( ; imageSimdY != imageSimdYEnd; imageSimdY += rowSize ) {
+                    const simd * src = reinterpret_cast <const simd*>(imageSimdY);
 
                     const simd data = _mm512_loadu_si512( src );
 
-                    const simd dataLo  = _mm512_unpacklo_epi8( data, zero );
-                    const simd dataHi  = _mm512_unpackhi_epi8( data, zero );
+                    const simd dataLo = _mm512_unpacklo_epi8( data, zero );
+                    const simd dataHi = _mm512_unpackhi_epi8( data, zero );
 
                     const simd data_1 = _mm512_unpacklo_epi16( dataLo, zero );
                     const simd data_2 = _mm512_unpackhi_epi16( dataLo, zero );
@@ -407,14 +407,14 @@ namespace avx512
                 _mm512_storeu_si512( dst, _mm512_add_epi32( simdSum_4, _mm512_loadu_si512( dst ) ) );
             }
 
-            if( nonSimdWidth > 0 ) {
+            if ( nonSimdWidth > 0 ) {
                 const uint8_t* imageXEnd = imageStart + nonSimdWidth;
 
-                for( ; imageStart != imageXEnd; ++imageStart, ++out ) {
+                for ( ; imageStart != imageXEnd; ++imageStart, ++out ) {
                     const uint8_t * imageY    = imageStart;
                     const uint8_t * imageYEnd = imageY + height * rowSize;
 
-                    for( ; imageY != imageYEnd; imageY += rowSize )
+                    for ( ; imageY != imageYEnd; imageY += rowSize )
                         (*out) += (*imageY);
                 }
             }
@@ -422,12 +422,12 @@ namespace avx512
         else {
             const uint8_t * imageYEnd = imageStart + height * rowSize;
 
-            for( ; imageStart != imageYEnd; imageStart += rowSize, ++out ) {
+            for ( ; imageStart != imageYEnd; imageStart += rowSize, ++out ) {
                 const simd * src    = reinterpret_cast <const simd*> (imageStart);
                 const simd * srcEnd = src + simdWidth;
                 simd simdSum = _mm512_setzero_si512();
 
-                for( ; src != srcEnd; ++src ) {
+                for ( ; src != srcEnd; ++src ) {
                     simd data = _mm512_loadu_si512( src );
 
                     simd dataLo  = _mm512_unpacklo_epi8( data, zero );
@@ -438,17 +438,17 @@ namespace avx512
                                                                            _mm512_unpackhi_epi16( sumLoHi, zero ) ) );
                 }
 
-                if( nonSimdWidth > 0 ) {
+                if ( nonSimdWidth > 0 ) {
                     const uint8_t * imageX    = imageStart + totalSimdWidth;
                     const uint8_t * imageXEnd = imageX + nonSimdWidth;
 
-                    for( ; imageX != imageXEnd; ++imageX )
+                    for ( ; imageX != imageXEnd; ++imageX )
                         (*out) += (*imageX);
                 }
 
                 uint32_t output[8] = { 0 };
                 _mm512_storeu_si512( reinterpret_cast <simd*>(output), simdSum );
-                
+
                 (*out) += output[0] + output[1] + output[2] + output[3] + output[4] + output[5] + output[6] + output[7];
             }
         }
@@ -457,25 +457,25 @@ namespace avx512
     void Subtract( uint32_t rowSizeIn1, uint32_t rowSizeIn2, uint32_t rowSizeOut, const uint8_t * in1Y, const uint8_t * in2Y,
                    uint8_t * outY, const uint8_t * outYEnd, uint32_t simdWidth, uint32_t totalSimdWidth, uint32_t nonSimdWidth )
     {
-        for( ; outY != outYEnd; outY += rowSizeOut, in1Y += rowSizeIn1, in2Y += rowSizeIn2 ) {
+        for ( ; outY != outYEnd; outY += rowSizeOut, in1Y += rowSizeIn1, in2Y += rowSizeIn2 ) {
             const simd * src1 = reinterpret_cast <const simd*> (in1Y);
             const simd * src2 = reinterpret_cast <const simd*> (in2Y);
             simd       * dst  = reinterpret_cast <simd*> (outY);
 
             const simd * src1End = src1 + simdWidth;
 
-            for( ; src1 != src1End; ++src1, ++src2, ++dst ) {
+            for ( ; src1 != src1End; ++src1, ++src2, ++dst ) {
                 simd data = _mm512_loadu_si512( src1 );
                 _mm512_storeu_si512( dst, _mm512_sub_epi8( data, _mm512_min_epu8( data, _mm512_loadu_si512( src2 ) ) ) );
             }
 
-            if( nonSimdWidth > 0 ) {
+            if ( nonSimdWidth > 0 ) {
                 const uint8_t * in1X = in1Y + totalSimdWidth;
                 const uint8_t * in2X = in2Y + totalSimdWidth;
                 uint8_t       * outX = outY + totalSimdWidth;
                 const uint8_t * outXEnd = outX + nonSimdWidth;
 
-                for( ; outX != outXEnd; ++outX, ++in1X, ++in2X )
+                for ( ; outX != outXEnd; ++outX, ++in1X, ++in2X )
                     (*outX) = static_cast<uint8_t>( (*in2X) > (*in1X) ? 0u : static_cast<uint32_t>(*in1X) - static_cast<uint32_t>(*in2X) );
             }
         }
@@ -487,11 +487,11 @@ namespace avx512
         simd simdSum = _mm512_setzero_si512();
         simd zero    = _mm512_setzero_si512();
 
-        for( ; imageY != imageYEnd; imageY += rowSize ) {
+        for ( ; imageY != imageYEnd; imageY += rowSize ) {
             const simd * src    = reinterpret_cast <const simd*> (imageY);
             const simd * srcEnd = src + simdWidth;
 
-            for( ; src != srcEnd; ++src ) {
+            for ( ; src != srcEnd; ++src ) {
                 simd data = _mm512_loadu_si512( src );
 
                 simd dataLo  = _mm512_unpacklo_epi8( data, zero );
@@ -502,16 +502,16 @@ namespace avx512
                                                                        _mm512_unpackhi_epi16( sumLoHi, zero ) ) );
             }
 
-            if( nonSimdWidth > 0 ) {
+            if ( nonSimdWidth > 0 ) {
                 const uint8_t * imageX    = imageY + totalSimdWidth;
                 const uint8_t * imageXEnd = imageX + nonSimdWidth;
 
-                for( ; imageX != imageXEnd; ++imageX )
+                for ( ; imageX != imageXEnd; ++imageX )
                     sum += (*imageX);
             }
         }
 
-        uint32_t output[8] ={ 0 };
+        uint32_t output[8] = { 0 };
 
         _mm512_storeu_si512( reinterpret_cast <simd*>(output), simdSum );
 

--- a/test/performance_tests/performance_test_image_function.cpp
+++ b/test/performance_tests/performance_test_image_function.cpp
@@ -366,6 +366,10 @@ namespace image_function_avx512
     SET_FUNCTION( BitwiseXor         )
     SET_FUNCTION( Invert             )
     SET_FUNCTION( Maximum            )
+    SET_FUNCTION( Minimum            )
+    SET_FUNCTION( ProjectionProfile  )
+    SET_FUNCTION( Subtract           )
+    SET_FUNCTION( Sum                )
 }
 #endif
 

--- a/test/unit_tests/unit_test_image_function.cpp
+++ b/test/unit_tests/unit_test_image_function.cpp
@@ -2612,6 +2612,10 @@ namespace avx512
     SET_FUNCTION_4_FORMS( Invert )
     SET_FUNCTION_4_FORMS( Maximum )
     SET_FUNCTION_4_FORMS( Minimum )
+    SET_FUNCTION_4_FORMS( ProjectionProfile )
+    SET_FUNCTION_4_FORMS( RgbToBgr )
+    SET_FUNCTION_4_FORMS( Subtract )
+    SET_FUNCTION_2_FORMS( Sum )
 }
 #endif
 


### PR DESCRIPTION
PR for #86 
I've added the support for avx512 to ProjectionProfile, Sum and Substract. It compile with -march=skylake-avx512.