### PR TITLE
Speeding up ARM and Python compilation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,12 +35,12 @@ matrix:
       before_script:
         - cd test/unit_tests
       script:
-        - make
+        - make -j 2
         - ./unit_tests
         - cd ../performance_tests
-        - make
+        - make -j 2
         - cd ../../examples
-        - make
+        - make -j 2
     - os: osx
       name: "OSX with QT latest"
       env: QT_BASE=latest CMAKE_OPTIONS=""

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ matrix:
       before_install: source script/travis/install_qt5.sh
     - os: linux
       language: python
-      name: "Python module compilation"
+      name: "Python 3.6 module compilation"
       python: 3.6
       env: SWIG=ON
       before_script:
@@ -55,7 +55,7 @@ matrix:
         - tar xzf rel-3.0.12.tar.gz && cd swig-rel-3.0.12
         - ./autogen.sh
         - ./configure --prefix=${HOME}/swig/
-        - make
+        - make -j 2
         - make install
         - export PATH=${HOME}/swig/bin:$PATH
         - swig -version

--- a/examples/file_operation/makefile
+++ b/examples/file_operation/makefile
@@ -2,6 +2,7 @@
 # Flags for C++ compiler
 ##
 PNG_NOT_EXISTS = $(shell g++ -lpng 2>&1 > /dev/null | grep 'cannot find' | wc -c)
+JPEG_NOT_EXISTS = $(shell g++ -ljpeg 2>&1 > /dev/null | grep 'cannot find' | wc -c)
 CXXFLAGS += -std=c++11 -Wall -Wextra -Wstrict-aliasing -Wpedantic -Wconversion -O2 -march=native
 
 SRC = *.cpp
@@ -17,22 +18,25 @@ all: example_file_operation
 
 clean:
 	$(RM) example_file_operation
+
+PNG_MESSAGE := ""
+JPEG_MESSAGE := ""
+
 ifeq ($(PNG_NOT_EXISTS),0)
 CXXFLAGS += -D PENGUINV_ENABLED_PNG_SUPPORT
 LDFLAGS += -lpng
-
-dep_error:
-	@echo
 else
-dep_error:
-	@echo 
-	@echo "Note! libpng-dev is missing from your computer,"
-	@echo "so .png images are not supported."
-	@echo
-	@echo "You can install libpng-dev by:"
-	@echo "$ sudo apt install libpng-dev"
-	@echo
+PNG_MESSAGE := "\nNote! libpng-dev is missing from your computer,\nso .png images are not supported.\n\nYou can install libpng-dev by:\n$ sudo apt install libpng-dev\n"
 endif
 
-example_file_operation: $(SRC) | dep_error
+ifeq ($(JPEG_NOT_EXISTS),0)
+CXXFLAGS += -D PENGUINV_ENABLED_JPEG_SUPPORT
+LIBS += -ljpeg
+else
+JPEG_MESSAGE := "\nNote! libjpeg-dev is missing from your computer,\nso .jpeg images are not supported.\n\nYou can install libjpeg-dev by:\n$ sudo apt install libjpeg-dev\n"
+endif
+
+example_file_operation: $(SRC)
+	@echo $(PNG_MESSAGE)
+	@echo $(JPEG_MESSAGE)
 	g++ $(CXXFLAGS) -o $@ $^ $(LDFLAGS)

--- a/examples/file_operation/makefile
+++ b/examples/file_operation/makefile
@@ -31,7 +31,7 @@ endif
 
 ifeq ($(JPEG_NOT_EXISTS),0)
 CXXFLAGS += -D PENGUINV_ENABLED_JPEG_SUPPORT
-LIBS += -ljpeg
+LDFLAGS += -ljpeg
 else
 JPEG_MESSAGE := "\nNote! libjpeg-dev is missing from your computer,\nso .jpeg images are not supported.\n\nYou can install libjpeg-dev by:\n$ sudo apt install libjpeg-dev\n"
 endif

--- a/test/unit_tests/Makefile
+++ b/test/unit_tests/Makefile
@@ -53,22 +53,15 @@ OBJFILES := $(addprefix $(BIN)/, $(foreach obj, $(OBJS), $(shell basename $(obj)
 
 all: $(BIN) $(TARGET)
 
+PNG_MESSAGE := ""
+JPEG_MESSAGE := ""
+
 ifeq ($(PNG_NOT_EXISTS),0)
 CFLAGS += -D PENGUINV_ENABLED_PNG_SUPPORT
 CXXFLAGS += -D PENGUINV_ENABLED_PNG_SUPPORT
 LIBS += -lpng
-
-png_note:
-	@echo
 else
-png_note:
-	@echo 
-	@echo "Note! libpng-dev is missing from your computer,"
-	@echo "so .png images are not supported."
-	@echo
-	@echo "You can install libpng-dev by:"
-	@echo "$ sudo apt install libpng-dev"
-	@echo
+PNG_MESSAGE := "\nNote! libpng-dev is missing from your computer,\nso .png images are not supported.\n\nYou can install libpng-dev by:\n$ sudo apt install libpng-dev\n"
 endif
 
 ifeq ($(JPEG_NOT_EXISTS),0)
@@ -78,17 +71,12 @@ LIBS += -ljpeg
 jpeg_note:
 	@echo
 else
-jpeg_note:
-	@echo 
-	@echo "Note! libjpeg-dev is missing from your computer,"
-	@echo "so .jpeg images are not supported."
-	@echo
-	@echo "You can install libjpeg-dev by:"
-	@echo "$ sudo apt install libjpeg-dev"
-	@echo
+JPEG_MESSAGE := "\nNote! libjpeg-dev is missing from your computer,\nso .jpeg images are not supported.\n\nYou can install libjpeg-dev by:\n$ sudo apt install libjpeg-dev\n"
 endif
 
-$(BIN): | png_note jpeg_note
+$(BIN):
+	@echo $(PNG_MESSAGE)
+	@echo $(JPEG_MESSAGE)
 	@mkdir -p $(BIN)
 
 $(TARGET): $(OBJFILES)

--- a/test/unit_tests/Makefile
+++ b/test/unit_tests/Makefile
@@ -67,9 +67,6 @@ endif
 ifeq ($(JPEG_NOT_EXISTS),0)
 CXXFLAGS += -D PENGUINV_ENABLED_JPEG_SUPPORT
 LIBS += -ljpeg
-
-jpeg_note:
-	@echo
 else
 JPEG_MESSAGE := "\nNote! libjpeg-dev is missing from your computer,\nso .jpeg images are not supported.\n\nYou can install libjpeg-dev by:\n$ sudo apt install libjpeg-dev\n"
 endif


### PR DESCRIPTION
Travis-CI supports 2 cores per job so we should use it to improve our code compilation speed