### PR TITLE
Set default clone depth to 50 in AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,9 @@ version: 1.0.{build}
 # Build worker image (VM template)
 image: Visual Studio 2015
 
+# No need to clone everything for build servers
+clone_depth: 50
+
 environment:
   matrix:
     - JOB: Release_x86


### PR DESCRIPTION
Like it's done in Travis-CI. It should slightly improve build time.