### PR TITLE
added CMake to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,16 @@ build/*
 .DS_store
 .Trashes
 ._*
+
+# CMake
+CMakeLists.txt.user
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+_deps


### PR DESCRIPTION
There's no issue for that (I didn't want to create any since it's minor). I recently noticed that there are no CMake related entries in .gitignore so I have added them.