### PR TITLE
Closes #644: Optimise Bitmap image saving function

### DIFF
--- a/src/file/bmp_image.cpp
+++ b/src/file/bmp_image.cpp
@@ -575,14 +575,15 @@ namespace Bitmap_Operation
 
         const uint8_t * imageY = image.data() + (startY + height - 1) * rowSize + startX * colorCount;
 
-        std::vector < uint8_t > temp( lineLength, 0 );
-
         const size_t imageLineSize = sizeof( uint8_t ) * width * colorCount;
 
-        for ( uint32_t rowId = 0; rowId < height; ++rowId, imageY -= rowSize ) {
-            memcpy( temp.data(), imageY, imageLineSize );
+        const std::streamsize alignmentDiff = static_cast<std::streamsize>(lineLength - imageLineSize);
+        const uint32_t zero = 0;
 
-            file.write( reinterpret_cast<const char *>( temp.data() ), static_cast<std::streamsize>( lineLength ) );
+        for ( uint32_t rowId = 0; rowId < height; ++rowId, imageY -= rowSize ) {
+
+            file.write( reinterpret_cast<const char *>( imageY ), static_cast<std::streamsize>( imageLineSize ) );
+            file.write( reinterpret_cast<const char *>( &zero ), alignmentDiff );
             file.flush();
         }
 


### PR DESCRIPTION
Closes #644 

These changes optimize the [image saving function](https://github.com/ihhub/penguinV/blob/fa0b34e790ce8f0e149c8b4f1eb2a4819fc28226/src/file/bmp_image.cpp#L523) in **src/file/bmp_image.cpp**.

During the saving process, instead of copying a line of the pass image to a temporary array, along with the extra bytes needed for proper alignment, and then writing it into the output file; it writes the line from the image and the extra bytes for proper alignment directly into the file.
