### PR TITLE
Add macOS compilation as a part of GitHub actions

### DIFF
--- a/.github/workflows/github_action.yml
+++ b/.github/workflows/github_action.yml
@@ -7,11 +7,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  build-ubuntu:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
     timeout-minutes: 30
     steps:
     - uses: actions/checkout@v2
@@ -21,6 +21,24 @@ jobs:
       run: cmake --build build --config Release -- -j 2
     - name: Run tests
       run: cd build && ctest -E 'perf_test' --extra-verbose # execute unit_test and unit_test_opencl
+  build-macos:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest]
+    timeout-minutes: 30
+    steps:
+    - uses: actions/checkout@v2
+    - name: Configure
+      run: mkdir build && cd build && cmake ..
+    - name: Build
+      run: cmake --build build --config Release -- -j 2
+    - name: Run tests
+      run: cd build && ctest -E 'perf_test' --extra-verbose # execute unit_test and unit_test_opencl
+      env:
+        # TODO: remove this disabled option. It was added due to libpng error:
+        #       libpng warning: Application built with libpng-1.4.12 but running with 1.6.42
+        PENGUINV_ENABLE_PNG_SUPPORT: OFF
   python_on_windows:
     runs-on: windows-latest
     strategy:

--- a/.github/workflows/github_action.yml
+++ b/.github/workflows/github_action.yml
@@ -32,15 +32,11 @@ jobs:
     - name: Configure
       run: mkdir build && cd build && cmake ..
     - name: Build
-      run: cmake --build build --config Release -- -j 2
+      # TODO: remove this disabled option. It was added due to libpng error:
+      #       libpng warning: Application built with libpng-1.4.12 but running with 1.6.42
+      run: cmake --build build --config Release -- -j 2 -DPENGUINV_ENABLED_PNG_SUPPORT=OFF
     - name: Run tests
       run: cd build && ctest -E 'perf_test' --extra-verbose # execute unit_test and unit_test_opencl
-      env:
-        # TODO: remove this disabled option. It was added due to libpng error:
-        #       libpng warning: Application built with libpng-1.4.12 but running with 1.6.42
-        PENGUINV_ENABLE_PNG_SUPPORT: OFF
-        # TODO: OpenCL does not work on macOS out of the box. Find a proper way to do it.
-        PENGUINV_BUILD_UNIT_TEST_OPENCL: OFF
   python_on_windows:
     runs-on: windows-latest
     strategy:

--- a/.github/workflows/github_action.yml
+++ b/.github/workflows/github_action.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Build
       # TODO: remove this disabled option. It was added due to libpng error:
       #       libpng warning: Application built with libpng-1.4.12 but running with 1.6.42
-      run: cmake -DPENGUINV_ENABLE_PNG_SUPPORT=OFF --build build --config Release -- -j 2 
+      run: cmake -DPENGUINV_ENABLE_PNG_SUPPORT=OFF --build build --config Release -j 2 --
     - name: Run tests
       run: cd build && ctest -E 'perf_test' --extra-verbose # execute unit_test and unit_test_opencl
   python_on_windows:

--- a/.github/workflows/github_action.yml
+++ b/.github/workflows/github_action.yml
@@ -39,6 +39,8 @@ jobs:
         # TODO: remove this disabled option. It was added due to libpng error:
         #       libpng warning: Application built with libpng-1.4.12 but running with 1.6.42
         PENGUINV_ENABLE_PNG_SUPPORT: OFF
+        # TODO: OpenCL does not work on macOS out of the box. Find a proper way to do it.
+        PENGUINV_BUILD_UNIT_TEST_OPENCL: OFF
   python_on_windows:
     runs-on: windows-latest
     strategy:

--- a/.github/workflows/github_action.yml
+++ b/.github/workflows/github_action.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest]
     timeout-minutes: 30
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/github_action.yml
+++ b/.github/workflows/github_action.yml
@@ -30,10 +30,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Configure
-      run: mkdir build && cd build && cmake -DPENGUINV_ENABLE_PNG_SUPPORT=OFF ..
+      # TODO: remove these disabled options. It was added due to compilation errors:
+      #       - libpng warning: Application built with libpng-1.4.12 but running with 1.6.42
+      #       - /Users/runner/work/penguinV/penguinV/src/file/jpeg_image.cpp:76:10: fatal error: 'jerror.h' file not found
+      run: mkdir build && cd build && cmake -DPENGUINV_ENABLE_PNG_SUPPORT=OFF -DPENGUINV_ENABLE_JPEG_SUPPORT=OFF ..
     - name: Build
-      # TODO: remove this disabled option. It was added due to libpng error:
-      #       libpng warning: Application built with libpng-1.4.12 but running with 1.6.42
       run: cmake --build build --config Release -- -j 2
     - name: Run tests
       run: cd build && ctest -E 'perf_test' --extra-verbose # execute unit_test and unit_test_opencl

--- a/.github/workflows/github_action.yml
+++ b/.github/workflows/github_action.yml
@@ -30,11 +30,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Configure
-      run: mkdir build && cd build && cmake ..
+      run: mkdir build && cd build && cmake -DPENGUINV_ENABLE_PNG_SUPPORT=OFF ..
     - name: Build
       # TODO: remove this disabled option. It was added due to libpng error:
       #       libpng warning: Application built with libpng-1.4.12 but running with 1.6.42
-      run: cmake -DPENGUINV_ENABLE_PNG_SUPPORT=OFF --build build --config Release -j 2 --
+      run: cmake --build build --config Release -- -j 2
     - name: Run tests
       run: cd build && ctest -E 'perf_test' --extra-verbose # execute unit_test and unit_test_opencl
   python_on_windows:

--- a/.github/workflows/github_action.yml
+++ b/.github/workflows/github_action.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Build
       # TODO: remove this disabled option. It was added due to libpng error:
       #       libpng warning: Application built with libpng-1.4.12 but running with 1.6.42
-      run: cmake --build build --config Release -- -j 2 -DPENGUINV_ENABLED_PNG_SUPPORT=OFF
+      run: cmake -DPENGUINV_ENABLE_PNG_SUPPORT=OFF --build build --config Release -- -j 2 
     - name: Run tests
       run: cd build && ctest -E 'perf_test' --extra-verbose # execute unit_test and unit_test_opencl
   python_on_windows:


### PR DESCRIPTION
A default compiler for macOS is clang in comparison with gcc on Ubuntu.