### PR TITLE
Set minimal OpenCL version to 2.1

### DIFF
--- a/doc/opencl/API_description.md
+++ b/doc/opencl/API_description.md
@@ -1,5 +1,7 @@
 # API description
 
+The minimum OpenCL version supported by this library is 2.1.
+
 ## Namespaces
 **penguinV**    
 - ***ImageOpenCL*** - a 8-bit image with default number of colors as 1 (gray-scale image). If the the number of color channels in this description is not implicitly specified then it is a 1 (gray-scale image).    

--- a/src/opencl/image_buffer_opencl.h
+++ b/src/opencl/image_buffer_opencl.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#define CL_TARGET_OPENCL_VERSION 210
+
 #if defined( __APPLE__ ) || defined( __MACOSX )
 #include <OpenCL/cl.h>
 #else

--- a/src/opencl/image_buffer_opencl.h
+++ b/src/opencl/image_buffer_opencl.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   penguinV: https://github.com/ihhub/penguinV                           *
- *   Copyright (C) 2017 - 2022                                             *
+ *   Copyright (C) 2017 - 2024                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *


### PR DESCRIPTION
This is reasonably old version (2015) that should be supported by all modern systems.

close #699